### PR TITLE
refactor: export defines "DTK_LIB_DIR_NAME" "DXXX_TRANSLATIONS_PATH" …

### DIFF
--- a/debian/libdtkcore-bin.install
+++ b/debian/libdtkcore-bin.install
@@ -1,2 +1,1 @@
-usr/lib/dtk2/*
 usr/lib/*/*/DCore/bin/*

--- a/src/dtk_build.prf
+++ b/src/dtk_build.prf
@@ -60,22 +60,27 @@ isEmpty(LIB_INSTALL_DIR) {
     }
 }
 
-isEmpty(BIN_INSTALL_DIR) {
-    TOOL_INSTALL_DIR=$$LIB_INSTALL_DIR/libdtk-$${VER_MAJ}.$${VER_MIN}.$${VER_PAT}/D$$upper($$member($$list($$split(TARGET,)), 3, 3))$$join($$list($$member($$list($$split(TARGET,)), 4, -1)))/bin
+LIB_VERSION_NAME = libdtk-$${VER_MAJ}.$${VER_MIN}.$${VER_PAT}
+MODULE_NAME = D$$upper($$member($$list($$split(TARGET,)), 3, 3))$$join($$list($$member($$list($$split(TARGET,)), 4, -1)))
+
+DEFINES += DTK_LIB_DIR_NAME=\\\"$$LIB_VERSION_NAME\\\"
+
+isEmpty(TOOL_INSTALL_DIR) {
+    TOOL_INSTALL_DIR=$$LIB_INSTALL_DIR/$$LIB_VERSION_NAME/$$MODULE_NAME/bin
 }
 
 isEmpty(target.path): target.path = $$LIB_INSTALL_DIR
 
 isEmpty(INCLUDE_INSTALL_DIR) {
     isEqual(TARGET, dtkcore) {
-        INCLUDE_INSTALL_DIR = $$PREFIX/include/libdtk-$${VER_MAJ}.$${VER_MIN}.$${VER_PAT}
+        INCLUDE_INSTALL_DIR = $$PREFIX/include/$$LIB_VERSION_NAME
     } else {
         INCLUDE_INSTALL_DIR = $${QT.dtkcore.includes}/..
     }
 }
 
 DTK_INCLUDEPATH = $$INCLUDE_INSTALL_DIR
-isEmpty(includes.path): includes.path = $$quote($$DTK_INCLUDEPATH/D$$upper($$member($$list($$split(TARGET,)), 3, 3))$$join($$list($$member($$list($$split(TARGET,)), 4, -1))),)
+isEmpty(includes.path): includes.path = $$quote($$DTK_INCLUDEPATH/$$MODULE_NAME,)
 
 !isEmpty(DTK_STATIC_LIB) {
     DEFINES += DTK_STATIC_LIB
@@ -84,4 +89,10 @@ isEmpty(includes.path): includes.path = $$quote($$DTK_INCLUDEPATH/D$$upper($$mem
 
 !isEmpty(DTK_STATIC_TRANSLATION) {
     DEFINES += DTK_STATIC_TRANSLATION
+}
+
+exists($$PWD/dtk_translation.prf) {
+    include($$PWD/dtk_translation.prf)
+} else {
+    load(dtk_translation)
 }

--- a/src/dtk_lib.prf
+++ b/src/dtk_lib.prf
@@ -1,9 +1,3 @@
-exists($$_PRO_FILE_PWD_/src/dtk_translation.prf) {
-    include($$_PRO_FILE_PWD_/src/dtk_translation.prf)
-} else {
-    load(dtk_translation)
-}
-
 TEMPLATE  = subdirs
 CONFIG += ordered
 

--- a/src/dtk_module.prf
+++ b/src/dtk_module.prf
@@ -115,18 +115,3 @@ QMAKE_PKGCONFIG_DESCRIPTION = Deepin Tool Kit $$TARGET header files
 QMAKE_PKGCONFIG_REQUIRES += $$DTK_MODULE_DEPENDS
 QMAKE_PKGCONFIG_INCDIR = $$includes.path
 QMAKE_PKGCONFIG_LIBDIR = $$target.path
-
-
-# -----------------------
-# Config translations
-!isEmpty(DTK_STATIC_TRANSLATION) {
-    QRC_PATH = $$mod_inst_pfx/../translations/$${TARGET}_translations.qrc
-    RESOURCES += $$QRC_PATH
-}
-
-TRANSLATIONS += $$mod_inst_pfx/.../translations/*
-
-dtk_translations.path = $$PREFIX/share/$${TARGET}/translations
-dtk_translations.files = $$mod_inst_pfx/../translations/*.qm
-
-INSTALLS += dtk_translations

--- a/src/dtk_translation.prf
+++ b/src/dtk_translation.prf
@@ -24,9 +24,9 @@ isEmpty(DTK_NO_TRANSLATION) {
         # qrc template
         #<RCC>
         #    <qresource prefix="/dtk/translations">
-        #        <file>dtkwidget2_am_ET.qm</file>
-        #        <file>dtkwidget2_ar.qm</file>
-        #        <file>dtkwidget2_ast.qm</file>
+        #        <file>dtkwidget_am_ET.qm</file>
+        #        <file>dtkwidget_ar.qm</file>
+        #        <file>dtkwidget_ast.qm</file>
         #    </qresource>
         #</RCC>
         QRC_PATH = $$ROOT_DIR/translations/$${BASENAME}_translations.qrc
@@ -44,3 +44,20 @@ isEmpty(DTK_NO_TRANSLATION) {
         write_file($$QRC_PATH, QRC_CONTENT) | error("Aborting.")
     }
 }
+
+!isEmpty(DTK_STATIC_TRANSLATION) {
+    QRC_PATH = $$mod_inst_pfx/../translations/$${TARGET}_translations.qrc
+    RESOURCES += $$QRC_PATH
+}
+
+TRANSLATIONS += $$mod_inst_pfx/../translations/*
+
+TRANSLATIONS_DIR = $$LIB_VERSION_NAME/$$MODULE_NAME/translations
+TRANSLATIONS_PATH = $$PREFIX/share/$$TRANSLATIONS_DIR
+DEFINES += $$upper($$MODULE_NAME)_TRANSLATIONS_PATH=\\\"$$TRANSLATIONS_PATH\\\"
+DEFINES += $$upper($$MODULE_NAME)_TRANSLATIONS_DIR=\\\"$$TRANSLATIONS_DIR\\\"
+
+dtk_translations.path = $$TRANSLATIONS_PATH
+dtk_translations.files = $$mod_inst_pfx/../translations/*.qm
+
+INSTALLS += dtk_translations

--- a/src/settings/backend/gsettingsbackend.cpp
+++ b/src/settings/backend/gsettingsbackend.cpp
@@ -48,9 +48,9 @@ public:
  * \class GSettingsBackend
  * \brief Storage backend of DSettings use gsettings.
  *
- * You should generate gsetting schema with /usr/lib/dtk2/dtk-settings.
+ * You should generate gsetting schema with /usr/lib/x86_64-linux-gnu/libdtk-$$VERSION/DCore/bin/dtk-settings.
  *
- * You can find this tool from libdtkcore-bin. use /usr/lib/dtk2/dtk-settings -h for help.
+ * You can find this tool from libdtkcore-bin. use /usr/lib/x86_64-linux-gnu/libdtk-$$VERSION/DCore/bin/dtk-settings -h for help.
  */
 
 GSettingsBackend::GSettingsBackend(DSettings *settings, QObject *parent) :

--- a/src/src.pro
+++ b/src/src.pro
@@ -112,10 +112,10 @@ linux {
     # dtk for qmake
     include(dtk_qmake.prf)
 
-    deepin_os_release_tool.files=$$PWD/../bin/deepin-os-release
-    deepin_os_release_tool.path=$$TOOL_INSTALL_DIR
+    tools.files=$$PWD/../bin/* $$PWD/../tools/script/*.py
+    tools.path=$$TOOL_INSTALL_DIR
 
-    INSTALLS += deepin_os_release_tool
+    INSTALLS += tools
 } else {
     prf.files-=$$PWD/dtk_qmake.prf
 }

--- a/tools/settings/settings.pro
+++ b/tools/settings/settings.pro
@@ -15,19 +15,10 @@ SOURCES += main.cpp
 isEmpty(PREFIX){
     PREFIX = /usr
 }
-isEmpty(BIN_INSTALL_DIR) {
-    BIN_INSTALL_DIR=$${PREFIX}/lib/dtk2
-}
+
 !isEmpty(DTK_STATIC_LIB){
     DEFINES += DTK_STATIC_LIB
 }
-
-target.path = $${BIN_INSTALL_DIR}
-
-script.files += $${PWD}/../script/*.py
-script.path = $${BIN_INSTALL_DIR}
-
-INSTALLS += target script
 
 win32:CONFIG(release, debug|release): LIBS += -L$$OUT_PWD/../../src/release/ -ldtkcore
 else:win32:CONFIG(debug, debug|release): LIBS += -L$$OUT_PWD/../../src/debug/ -ldtkcore
@@ -35,3 +26,4 @@ else:unix: LIBS += -L$$OUT_PWD/../../src/ -ldtkcore
 
 INCLUDEPATH += $$PWD/../../src
 DEPENDPATH += $$PWD/../../src
+DESTDIR = $$_PRO_FILE_PWD_/../../bin


### PR DESCRIPTION
…"DXXX_TRANSLATIONS_DIR"

reset the translate file path to "/usr/share/libdtk-2.0.16/DXXX/translations"

修正翻译文件的安装路径，导出几个C++宏