### PR TITLE
feat: Ported to win10 platform

### DIFF
--- a/src/ddesktopentry.h
+++ b/src/ddesktopentry.h
@@ -31,7 +31,7 @@
 DCORE_BEGIN_NAMESPACE
 
 class DDesktopEntryPrivate;
-class DDesktopEntry
+class LIBDTKCORESHARED_EXPORT DDesktopEntry
 {
     Q_GADGET
 public:

--- a/src/util/dvtablehook.h
+++ b/src/util/dvtablehook.h
@@ -31,7 +31,7 @@
 
 DCORE_BEGIN_NAMESPACE
 
-class DVtableHook
+class LIBDTKCORESHARED_EXPORT DVtableHook
 {
 public:
     static inline quintptr toQuintptr(const void *ptr)

--- a/tests/dutils/dutiltester.cpp
+++ b/tests/dutils/dutiltester.cpp
@@ -229,6 +229,7 @@ void TestDUtil::testGroups()
 
 void TestDUtil::testSysInfo()
 {
+#ifdef Q_OS_LINUX
     qDebug() << DSysInfo::uosType() <<
                 DSysInfo::uosEditionType() <<
                 DSysInfo::uosArch() <<
@@ -240,4 +241,5 @@ void TestDUtil::testSysInfo()
                 DSysInfo::majorVersion() <<
                 DSysInfo::minorVersion() <<
                 DSysInfo::buildVersion() ;
+#endif
 }


### PR DESCRIPTION
Transplant the project to win10 x64 platform, use QtCreator 5.12.9
(MinGW -64) to compile and run successfully.