### PR TITLE
style:Improve log file name

### DIFF
--- a/src/log/RollingFileAppender.cpp
+++ b/src/log/RollingFileAppender.cpp
@@ -59,7 +59,7 @@ QString RollingFileAppender::datePatternString() const
 
 void RollingFileAppender::setDatePattern(DatePattern datePattern)
 {
-  setDatePatternString(QLatin1String("'.'yyyy-MM-dd-hh-mm-zzz"));
+  setDatePatternString(QLatin1String("'.'yyyy-MM-dd-hh-mm-ss-zzz"));
 
   QMutexLocker locker(&m_rollingMutex);
   m_frequency = datePattern;


### PR DESCRIPTION
被分割的日志文件，名称包含毫秒却缺少秒。完善该信息有助于在大量日志文件中快速找到准确时间段的日志文件。

Log: 优化日志文件名称