### PR TITLE
Update dsysinfo.cpp

### DIFF
--- a/src/dsysinfo.cpp
+++ b/src/dsysinfo.cpp
@@ -439,10 +439,10 @@ void DSysInfoPrivate::ensureComputerInfo()
     }
 
     // Getting Disk Size
-    const QString &deviceName = QStorageInfo::root().device();
+    QString deviceName;
     QProcess lsblk;
 
-    lsblk.start("lsblk", {"-Jlpb", "-oNAME,KNAME,PKNAME,SIZE"}, QIODevice::ReadOnly);
+    lsblk.start("lsblk", {"-Jlpb", "-oNAME,KNAME,PKNAME,SIZE,MOUNTPOINT"}, QIODevice::ReadOnly);
 
     if (!lsblk.waitForFinished()) {
         return;
@@ -462,6 +462,11 @@ void DSysInfoPrivate::ensureComputerInfo()
             QString kname = oneValue.toObject().value("kname").toString();
             QString pkname = oneValue.toObject().value("pkname").toString();
             qulonglong size = oneValue.toObject().value("size").toVariant().toULongLong();
+            QString deviceNameMP = oneValue.toObject().value("mountpoint").toString();
+            
+            if ("/" ==  deviceNameMP){
+                deviceName = name;
+            }
 
             if (keyName.isNull() && deviceName == name) {
                 keyName = kname;


### PR DESCRIPTION
QStorageInfo::root().device()扫描的是/etc/mtab里的内容，但是有的根节点就只会显示/dev/root，这个会导致在控制中心显示磁盘容量的时候不能 显示，故现更改获取根挂载点的方式，在lsblk的方法上增加。