### PR TITLE
fix: DSetting unit error and crash randomly

### DIFF
--- a/src/settings/dsettings.cpp
+++ b/src/settings/dsettings.cpp
@@ -281,6 +281,14 @@ void DSettings::setBackend(DSettingsBackend *backend)
     this, [ = ](const QString & key, const QVariant & value) {
         option(key)->setValue(value);
     });
+    // exit and delete thread
+    connect(this, &DSettings::destroyed, this, [backendWriteThread](){
+        if (backendWriteThread->isRunning()) {
+            backendWriteThread->quit();
+            backendWriteThread->wait();
+        }
+        backendWriteThread->deleteLater();
+    });
 
     backendWriteThread->start();
 

--- a/tests/tests.pro
+++ b/tests/tests.pro
@@ -24,7 +24,7 @@ DEPENDPATH += $$PWD/../src
 
 unix: {
 QMAKE_RPATHDIR += $$OUT_PWD/../src
-LIBS += -L$$OUT_PWD/../src/ -ldtkcore -lgtest
+LIBS += -lgtest
 # for dlsym
 LIBS += -ldl
 # TODO: vtabhook release test failed

--- a/tests/ut_qsettingsbackend.cpp
+++ b/tests/ut_qsettingsbackend.cpp
@@ -100,7 +100,7 @@ TEST_F(ut_QSettingsBackend, testQSettingsBackendDoOption)
 {
     QPointer<DSettings> tmpSetting = DSettings::fromJson(jsonContent.toLatin1());
     QScopedPointer<DSettings> scopeSettings(tmpSetting.data());
-    static QSettingBackend qBackend("/tmp/test.ini");
+    QSettingBackend qBackend("/tmp/test.ini");
     scopeSettings->setBackend(&qBackend);
     Q_EMIT qBackend.setOption("Test", true);
 
@@ -108,4 +108,7 @@ TEST_F(ut_QSettingsBackend, testQSettingsBackendDoOption)
     ASSERT_TRUE(!qKeys.isEmpty());
     QVariant value = qBackend.getOption("Test");
     ASSERT_TRUE(!value.toBool());
+
+    // ensure `DSettings` is released before `SettingBackend` if `doSetOption` maybe execute.
+    scopeSettings.reset();
 }


### PR DESCRIPTION
DSettingsBackend::doSetOption is executing when `DSettings` has
been destroyed, because `doSetOption` is connected in `QueuedConnection`
way, this would be ensure `backendWriteThread`'seventloop is exited
when `DSetting` destoryed.

we ensure `DSettings` is released before `SettingBackend`, so that
`SettingBackend`'s slot would not be executed when `DSetting` destoryed.

we also should ensure `SettinBackend` is thread safely, because os
`DSettings` has backendWriteThread to execute doSetOption, and getOption,
is execute in main thread.

remove link of libdtkcore in qmake, because we compile it's source code
in unit test.

Log:
Influence: none