### PR TITLE
fix: application crash when dconfig is invalid

### DIFF
--- a/tests/ut_dconfig.cpp
+++ b/tests/ut_dconfig.cpp
@@ -40,7 +40,7 @@ protected:
         metaGuard = new FileCopyGuard(":/data/dconf-example.meta.json", QString("%1" PREFIX"/share/dsg/configs/%2/%3.json").arg(fileBackendLocalPerfix.value(), APP_ID, FILE_NAME));
 
         backendType.set("DSG_DCONFIG_BACKEND_TYPE", "FileBackend");
-        dsgDataDir.set("DSG_DATA_DIRS", "/usr/share/dsg");
+        dsgDataDir.set("DSG_DATA_DIRS", PREFIX"/share/dsg");
     }
     static void TearDownTestCase() {
         QDir(fileBackendLocalPerfix.value()).removeRecursively();

--- a/tests/ut_dconfigfile.cpp
+++ b/tests/ut_dconfigfile.cpp
@@ -36,6 +36,7 @@ class ut_DConfigFile : public testing::Test
 protected:
     static void SetUpTestCase() {
         home.set("HOME", "/tmp/home");
+        dsgDataDir.set("DSG_DATA_DIRS", PREFIX"/share/dsg");
     }
     static void TearDownTestCase() {
         dsgDataDir.restore();


### PR DESCRIPTION
Add invalid check for all DConfig's method(avoid null pointer dereference).
fallback to FileBackend when DBusBackend can't be created.

set correct environment value in unit test.

Log:
Influence: all application crash when dconfig is invalid but still
call other method expect isValid.

Change-Id: I7395f44518989cb14a09306fcfd4db380608a24e