### PR TITLE
fix: DConfig can't find resource

### DIFF
--- a/src/filesystem/filesystem.pri
+++ b/src/filesystem/filesystem.pri
@@ -2,7 +2,9 @@ include($$PWD/private/private.pri)
 
 INCLUDEPATH += $$PWD/../base
 
-DEFINES += PREFIX=\\\"$$PREFIX\\\"
+INSTALL_PREFIX=$$QT_INSTALL_PREFIX
+isEmpty(INSTALL_PREFIX): INSTALL_PREFIX=$$[QT_INSTALL_PREFIX]
+DEFINES += PREFIX=\\\"$$INSTALL_PREFIX\\\"
 
 HEADERS += \
     $$PWD/dbasefilewatcher.h \


### PR DESCRIPTION
dde-config-daemon loads resouce from `$$PREFIX/share/dsg` when default
action, and `PREFIX`'s value is empty.
set default value for PREFIX from QT_INSTALL_PREFIX(/usr).

Log: 
Influence: 开发dtkcore，但没有指定PREFIX值，导致配置策略加载失败
Change-Id: I97573c283365aa581d5e93eb75d27259134f10af