### PR TITLE
chore: dtkcore_config.h miss include some Class

### DIFF
--- a/src/src.pro
+++ b/src/src.pro
@@ -56,11 +56,6 @@ include($$PWD/log/log.pri)
 include($$PWD/filesystem/filesystem.pri)
 include($$PWD/settings/settings.pri)
 
-DTK_MODULE_NAME = $$TARGET
-load(dtk_build)
-
-# ----------------------------------------------
-# install config
 includes.files += \
     $$PWD/*.h \
     $$PWD/dtkcore_config.h \
@@ -70,6 +65,12 @@ includes.files += \
     $$PWD/DDesktopEntry \
     $$PWD/DConfigFile \
     $$PWD/DConfig
+
+# ----------------------------------------------
+# install config
+
+DTK_MODULE_NAME = $$TARGET
+load(dtk_build)
 
 INSTALLS += includes target
 


### PR DESCRIPTION
`include.files+=` is behind `load(dtk_build)`, so those files don't
execute dtk_build function, it casues dtkcore_config.h don't include
`include.files` in `dtk_build` back.

Log: 
Influence: none
Change-Id: I06afe3df5c80145d7d9ff9da281571a9725366d5