### PR TITLE
chore: build doxygen documentation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,16 @@
+cmake_minimum_required (VERSION 3.10)
+
+project (DtkCore
+	VERSION "${DTK_REPO_MODULE_VERSION}"
+	DESCRIPTION "DTK Core module"
+	HOMEPAGE_URL ""
+	LANGUAGES CXX C
+)
+
+find_package (Qt5 CONFIG REQUIRED COMPONENTS DBus Xml)
+
+set (BUILD_DOCS ON CACHE BOOL "Generate doxygen-based documentation")
+
+if (BUILD_DOCS)
+	add_subdirectory(doc)
+endif ()

--- a/debian/rules
+++ b/debian/rules
@@ -15,7 +15,7 @@ else
 endif
 
 %:
-	dh $@ --parallel
+	dh $@ --buildsystem=qmake --parallel
 
 override_dh_auto_configure:
 	dh_auto_configure -- LIB_INSTALL_DIR=/usr/lib/$(DEB_HOST_MULTIARCH) VERSION=$(CONFIG_VERSION)

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -1,0 +1,38 @@
+cmake_minimum_required (VERSION 3.10)
+
+find_package (Doxygen REQUIRED)
+
+set (QCH_INSTALL_DESTINATION ${CMAKE_INSTALLL_PREFIX}/share/DDE/dtk CACHE STRING "QCH install location")
+
+set (DOXYGEN_GENERATE_HTML "NO" CACHE STRING "Doxygen HTML output")
+set (DOXYGEN_GENERATE_XML "NO" CACHE STRING "Doxygen XML output")
+set (DOXYGEN_GENERATE_QHP "YES" CACHE STRING "Doxygen QHP output")
+set (DOXYGEN_FILE_PATTERNS *.cpp *.h *.md *.zh_CN.dox CACHE STRING "Doxygen File Patterns")
+set (DOXYGEN_PROJECT_NUMBER ${CMAKE_PROJECT_VERSION} CACHE STRING "") # Should be the same as this project is using.
+set (DOXYGEN_EXTRACT_STATIC YES)
+set (DOXYGEN_OUTPUT_LANGUAGE "Chinese")
+set (DOXYGEN_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/docs/)
+set (DOXYGEN_QHG_LOCATION "qhelpgenerator")
+set (DOXYGEN_QHP_NAMESPACE "org.deepin.dtk.core")
+set (DOXYGEN_QCH_FILE "dtkcore.qch")
+set (DOXYGEN_QHP_VIRTUAL_FOLDER "dtkcore")
+set (DOXYGEN_HTML_EXTRA_STYLESHEET "" CACHE STRING "Doxygen custom stylesheet for HTML output")
+set (DOXYGEN_TAGFILES "qtcore.tags=qthelp://org.qt-project.qtcore/qtcore/" CACHE STRING "Doxygen tag files")
+
+set (DOXYGEN_PREDEFINED
+    "\"DCORE_BEGIN_NAMESPACE=namespace Dtk { namespace Core {\""
+    "\"DCORE_END_NAMESPACE=}}\""
+    "\"DCORE_USE_NAMESPACE=using Dtk::Core\""
+)
+set (DOXYGEN_MACRO_EXPANSION "YES")
+set (DOXYGEN_EXPAND_ONLY_PREDEF "YES")
+
+doxygen_add_docs (doxygen
+    ${PROJECT_SOURCE_DIR}/src
+    ${PROJECT_SOURCE_DIR}/doc
+    ALL
+    WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+    COMMENT "Generate documentation via Doxygen"
+)
+
+install (FILES ${PROJECT_BINARY_DIR}/docs/html/dtkcore.qch DESTINATION ${QCH_INSTALL_DESTINATION})


### PR DESCRIPTION
追加基于 doxygen 的文档构建

说明：

1. 目前并不会打包文档包，也不会自动生成和发布文档。文档包会在后续 PR 中提供，在线文档的生成和发布会在以后的 CI 流程中进行
2. 为了各个项目统一，文档会固定生成在对应 build 目录内的 docs 子目录中
3. 默认只生成 QCH 文档，但对外暴露了其他格式的生成选项，以便通过 cmake 的缓存变量的形式控制实际行为，也可通过 `ccmake` 等工具调整对应的值
4. 生成 HTML 文档的参考命令：`cmake ../ -DDOXYGEN_GENERATE_HTML="YES" -DDOXYGEN_HTML_EXTRA_STYLESHEET="/path/to/extra-stylesheet.css" -DDOXYGEN_TAGFILES="qtcore.tags=http://qt-project.org/doc/qt-5/"`
5. 若要确保对 Qt 类型的正确生成，则需先拷贝 Qt 的 tags 文件（比如 `/usr/share/doc/qt/qtcore/qtcore.tags`）到 doxygen 的工作目录（此例为源码根目录），然后再进行文档的生成