### PR TITLE
feat: add the permission management for files

### DIFF
--- a/include/DtkCore/DCapDir
+++ b/include/DtkCore/DCapDir
@@ -1,0 +1,1 @@
+#include "dcapfile.h"

--- a/include/DtkCore/DCapFile
+++ b/include/DtkCore/DCapFile
@@ -1,0 +1,1 @@
+#include "dcapfile.h"

--- a/include/DtkCore/DCapManager
+++ b/include/DtkCore/DCapManager
@@ -1,0 +1,1 @@
+#include "dcapmanager.h"

--- a/include/filesystem/dcapfile.h
+++ b/include/filesystem/dcapfile.h
@@ -1,0 +1,105 @@
+// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#ifndef DCAPFILE_H
+#define DCAPFILE_H
+
+#include <dtkcore_global.h>
+
+#include <DObject>
+#include <QDir>
+#include <QFile>
+
+DCORE_BEGIN_NAMESPACE
+
+class DCapFilePrivate;
+class DCapFile : public QFile, public DObject
+{
+    Q_OBJECT
+    D_DECLARE_PRIVATE(DCapFile)
+    Q_DISABLE_COPY(DCapFile)
+
+public:
+    explicit DCapFile(QObject *parent = nullptr);
+    DCapFile(const QString &name, QObject *parent = nullptr);
+
+    ~DCapFile() override;
+
+    void setFileName(const QString &name);
+
+    bool exists() const;
+    static bool exists(const QString &fileName);
+
+#if QT_DEPRECATED_SINCE(5, 13)
+    D_DECL_DEPRECATED_X("Use QFile::symLinkTarget() instead")
+    QString readLink() const;
+#endif
+#if QT_VERSION >= QT_VERSION_CHECK(5, 13, 0)
+    QString symLinkTarget() const;
+#endif
+    bool remove();
+    static bool remove(const QString &fileName);
+
+#if QT_VERSION >= QT_VERSION_CHECK(5, 15, 0)
+    bool moveToTrash();
+    static bool moveToTrash(const QString &fileName, QString *pathInTrash = nullptr);
+#endif
+
+    bool rename(const QString &newName);
+    static bool rename(const QString &oldName, const QString &newName);
+
+    bool link(const QString &newName);
+    static bool link(const QString &oldname, const QString &newName);
+
+    bool copy(const QString &newName);
+    static bool copy(const QString &fileName, const QString &newName);
+
+    bool open(OpenMode flags) override;
+
+    bool resize(qint64 sz) override;
+    static bool resize(const QString &filename, qint64 sz);
+
+private:
+    bool open(FILE *f, OpenMode ioFlags, FileHandleFlags handleFlags=DontCloseHandle);
+    bool open(int fd, OpenMode ioFlags, FileHandleFlags handleFlags=DontCloseHandle);
+};
+
+class DCapDirPrivate;
+class DCapDir : public QDir
+{
+public:
+    DCapDir(const DCapDir &);
+    DCapDir(const QString &path = QString());
+    DCapDir(const QString &path, const QString &nameFilter,
+         SortFlags sort = SortFlags(Name | IgnoreCase), Filters filter = AllEntries);
+    ~DCapDir();
+
+    void setPath(const QString &path);
+
+    bool cd(const QString &dirName);
+
+    QStringList entryList(Filters filters = NoFilter, SortFlags sort = NoSort) const;
+    QStringList entryList(const QStringList &nameFilters, Filters filters = NoFilter,
+                          SortFlags sort = NoSort) const;
+
+    QFileInfoList entryInfoList(Filters filters = NoFilter, SortFlags sort = NoSort) const;
+    QFileInfoList entryInfoList(const QStringList &nameFilters, Filters filters = NoFilter,
+                                SortFlags sort = NoSort) const;
+
+    bool mkdir(const QString &dirName) const;
+    bool rmdir(const QString &dirName) const;
+    bool mkpath(const QString &dirPath) const;
+    bool rmpath(const QString &dirPath) const;
+    bool exists() const;
+    bool remove(const QString &fileName);
+    bool rename(const QString &oldName, const QString &newName);
+    bool exists(const QString &name) const;
+
+private:
+    QSharedDataPointer<DCapDirPrivate> dd_ptr;
+};
+
+DCORE_END_NAMESPACE
+Q_DECLARE_SHARED(DTK_CORE_NAMESPACE::DCapDir)
+#endif // DCAPFILE_H

--- a/include/filesystem/dcapmanager.h
+++ b/include/filesystem/dcapmanager.h
@@ -1,0 +1,37 @@
+// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#ifndef DCAPMANAGER_H
+#define DCAPMANAGER_H
+
+#include <DObject>
+
+#include <QObject>
+
+DCORE_BEGIN_NAMESPACE
+class DCapManagerPrivate;
+class DCapManager : public QObject, public DObject
+{
+    Q_OBJECT
+    Q_DISABLE_COPY(DCapManager)
+    D_DECLARE_PRIVATE(DCapManager)
+public:
+    static DCapManager *instance();
+    static void registerFileEngine();
+    static void unregisterFileEngine();
+
+    void appendPath(const QString &path);
+    void appendPaths(const QStringList &pathList);
+
+    void removePath(const QString &path);
+    void removePaths(const QStringList &paths);
+
+    QStringList paths() const;
+
+protected:
+    explicit DCapManager();
+};
+
+DCORE_END_NAMESPACE
+#endif // DCAPMANAGER_H

--- a/src/filesystem/dcapfile.cpp
+++ b/src/filesystem/dcapfile.cpp
@@ -1,0 +1,386 @@
+// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#include "dcapfile.h"
+#include "dobject_p.h"
+#include "dcapmanager.h"
+#include "private/dcapfsfileengine_p.h"
+
+#include <private/qdir_p.h>
+
+DCORE_BEGIN_NAMESPACE
+
+extern QString _d_cleanPath(const QString &path);
+extern bool _d_isSubFileOf(const QString &filePath, const QString &directoryPath);
+
+class DCapFilePrivate : public DObjectPrivate
+{
+    D_DECLARE_PUBLIC(DCapFile)
+public:
+    DCapFilePrivate(DCapFile *qq, const QString &fileName = QString());
+    static bool canReadWrite(const QString &path);
+
+    QString fileName;
+};
+
+DCapFilePrivate::DCapFilePrivate(DCapFile *qq, const QString &fileName)
+    : DObjectPrivate(qq)
+    , fileName(fileName)
+{
+}
+
+bool DCapFilePrivate::canReadWrite(const QString &path)
+{
+    DCapFSFileEngine engine(path);
+    return engine.canReadWrite(path);
+}
+
+DCapFile::DCapFile(QObject *parent)
+    : QFile(parent)
+    , DObject(*new DCapFilePrivate(this))
+{
+
+}
+
+DCapFile::DCapFile(const QString &name, QObject *parent)
+    : QFile(name, parent)
+    , DObject(*new DCapFilePrivate(this, name))
+{
+}
+
+DCapFile::~DCapFile()
+{
+
+}
+
+void DCapFile::setFileName(const QString &name)
+{
+    D_D(DCapFile);
+    d->fileName = name;
+    return QFile::setFileName(name);
+}
+
+bool DCapFile::exists() const
+{
+    D_DC(DCapFile);
+    if (!d->canReadWrite(d->fileName))
+        return false;
+
+    return QFile::exists();
+}
+
+bool DCapFile::exists(const QString &fileName)
+{
+    return DCapFile(fileName).exists();
+}
+
+QString DCapFile::readLink() const
+{
+    D_DC(DCapFile);
+    if (!d->canReadWrite(d->fileName))
+        return {};
+
+    return QFile::readLink();
+}
+
+#if QT_VERSION >= QT_VERSION_CHECK(5, 13, 0)
+QString DCapFile::symLinkTarget() const
+{
+    return readLink();
+}
+#endif
+
+bool DCapFile::remove()
+{
+    D_D(DCapFile);
+    if (!d->canReadWrite(d->fileName))
+        return false;
+
+    return QFile::remove();
+}
+
+bool DCapFile::remove(const QString &fileName)
+{
+    return DCapFile(fileName).remove();
+}
+
+#if QT_VERSION >= QT_VERSION_CHECK(5, 15, 0)
+bool DCapFile::moveToTrash()
+{
+    D_D(DCapFile);
+    if (!d->canReadWrite(d->fileName))
+        return false;
+
+    return QFile::moveToTrash();
+}
+
+bool DCapFile::moveToTrash(const QString &fileName, QString *pathInTrash)
+{
+    DCapFile file(fileName);
+    if (file.moveToTrash()) {
+        if (pathInTrash)
+            *pathInTrash = file.fileName();
+        return true;
+    }
+    return false;
+}
+#endif
+
+bool DCapFile::rename(const QString &newName)
+{
+    D_D(DCapFile);
+    if (!d->canReadWrite(newName))
+        return false;
+
+    return QFile::rename(newName);
+}
+
+bool DCapFile::rename(const QString &oldName, const QString &newName)
+{
+    if (!DCapFilePrivate::canReadWrite(oldName))
+        return false;
+
+    return DCapFile(oldName).rename(newName);
+}
+
+bool DCapFile::link(const QString &newName)
+{
+    D_D(DCapFile);
+    if (!d->canReadWrite(newName))
+        return false;
+
+    return QFile::link(newName);
+}
+
+bool DCapFile::link(const QString &oldName, const QString &newName)
+{
+    if (!DCapFilePrivate::canReadWrite(oldName))
+        return false;
+
+    return DCapFile(oldName).link(newName);
+}
+
+bool DCapFile::copy(const QString &newName)
+{
+    D_D(DCapFile);
+    if (!d->canReadWrite(newName))
+        return false;
+
+    return QFile::copy(newName);
+}
+
+bool DCapFile::copy(const QString &fileName, const QString &newName)
+{
+    if (!DCapFilePrivate::canReadWrite(fileName))
+        return false;
+
+    return DCapFile(fileName).copy(newName);
+}
+
+bool DCapFile::open(QIODevice::OpenMode flags)
+{
+    D_D(DCapFile);
+    if (!d->canReadWrite(d->fileName))
+        return false;
+
+    return QFile::open(flags);
+}
+
+bool DCapFile::resize(qint64 sz)
+{
+    D_D(DCapFile);
+    if (!d->canReadWrite(d->fileName))
+        return false;
+
+    return QFile::resize(sz);
+}
+
+bool DCapFile::resize(const QString &fileName, qint64 sz)
+{
+    return DCapFile(fileName).resize(sz);
+}
+
+bool DCapFile::open(FILE *, QIODevice::OpenMode, QFileDevice::FileHandleFlags)
+{
+    return false;
+}
+
+bool DCapFile::open(int, QIODevice::OpenMode, QFileDevice::FileHandleFlags)
+{
+    return false;
+}
+
+class DCapDirPrivate  : public QSharedData
+{
+public:
+    DCapDirPrivate(QString filePath);
+    explicit DCapDirPrivate(const DCapDirPrivate &copy);
+
+    QString filePath;
+};
+
+DCapDirPrivate::DCapDirPrivate(QString filePath)
+    : filePath(filePath)
+{
+}
+
+DCapDirPrivate::DCapDirPrivate(const DCapDirPrivate &copy)
+    : QSharedData(copy)
+    , filePath(copy.filePath)
+{
+}
+
+DCapDir::DCapDir(const DCapDir &dir)
+    : QDir(dir)
+    , dd_ptr(dir.dd_ptr)
+{
+
+}
+
+DCapDir::DCapDir(const QString &path)
+    : QDir(path)
+    , dd_ptr(new DCapDirPrivate(path))
+{
+
+}
+
+DCapDir::DCapDir(const QString &path, const QString &nameFilter,
+                 QDir::SortFlags sort, QDir::Filters filter)
+    : QDir(path, nameFilter, sort, filter)
+    , dd_ptr(new DCapDirPrivate(path))
+{
+
+}
+
+DCapDir::~DCapDir()
+{
+
+}
+
+void DCapDir::setPath(const QString &path)
+{
+    dd_ptr = new DCapDirPrivate(path);
+    return QDir::setPath(path);
+}
+
+bool DCapDir::cd(const QString &dirName)
+{
+    auto old_d = d_ptr;
+    bool ret = QDir::cd(dirName);
+    if (!ret)
+        return ret;
+
+    // take the new path.
+    auto path = QDir::filePath("");
+    QScopedPointer<DCapFSFileEngine> fsEngine(new DCapFSFileEngine(path));
+    if (fsEngine->fileFlags(QAbstractFileEngine::FlagsMask) & QAbstractFileEngine::ExistsFlag) {
+        dd_ptr = new DCapDirPrivate(path);
+        return true;
+    }
+    d_ptr = old_d;
+    return false;
+}
+
+QStringList DCapDir::entryList(DCapDir::Filters filters, DCapDir::SortFlags sort) const
+{
+    const QDirPrivate* d = d_ptr.constData();
+    return entryList(d->nameFilters, filters, sort);
+}
+
+QStringList DCapDir::entryList(const QStringList &nameFilters, DCapDir::Filters filters, DCapDir::SortFlags sort) const
+{
+    if (!DCapFilePrivate::canReadWrite(dd_ptr->filePath))
+        return {};
+    return QDir::entryList(nameFilters, filters, sort);
+}
+
+QFileInfoList DCapDir::entryInfoList(QDir::Filters filters, QDir::SortFlags sort) const
+{
+    const QDirPrivate* d = d_ptr.constData();
+    return entryInfoList(d->nameFilters, filters, sort);
+}
+
+QFileInfoList DCapDir::entryInfoList(const QStringList &nameFilters, DCapDir::Filters filters, DCapDir::SortFlags sort) const
+{
+    if (!DCapFilePrivate::canReadWrite(dd_ptr->filePath))
+        return {};
+    return QDir::entryInfoList(nameFilters, filters, sort);
+}
+
+bool DCapDir::mkdir(const QString &dirName) const
+{
+    QString fn = filePath(dirName);
+    if (!DCapFilePrivate::canReadWrite(fn))
+        return false;
+
+    return QDir::mkdir(dirName);
+}
+
+bool DCapDir::rmdir(const QString &dirName) const
+{
+    QString fn = filePath(dirName);
+    if (!DCapFilePrivate::canReadWrite(fn))
+        return false;
+
+    return QDir::rmdir(dirName);
+}
+
+bool DCapDir::mkpath(const QString &dirPath) const
+{
+    QString fn = filePath(dirPath);
+    if (!DCapFilePrivate::canReadWrite(fn))
+        return false;
+
+    return QDir::mkpath(dirPath);
+}
+
+bool DCapDir::rmpath(const QString &dirPath) const
+{
+    QString fn = filePath(dirPath);
+    if (!DCapFilePrivate::canReadWrite(fn))
+        return false;
+
+    return QDir::rmpath(dirPath);
+}
+
+bool DCapDir::exists() const
+{
+    if (!DCapFilePrivate::canReadWrite(dd_ptr->filePath))
+        return false;
+
+    return QDir::exists();
+}
+
+bool DCapDir::exists(const QString &name) const
+{
+    if (name.isEmpty()) {
+        qWarning("DCapFile::exists: Empty or null file name");
+        return false;
+    }
+    return DCapFile::exists(filePath(name));
+}
+
+bool DCapDir::remove(const QString &fileName)
+{
+    if (fileName.isEmpty()) {
+        qWarning("DCapDir::remove: Empty or null file name");
+        return false;
+    }
+    return DCapFile::remove(filePath(fileName));
+}
+
+bool DCapDir::rename(const QString &oldName, const QString &newName)
+{
+    if (oldName.isEmpty() || newName.isEmpty()) {
+        qWarning("DCapDir::rename: Empty or null file name(s)");
+        return false;
+    }
+
+    DCapFile file(filePath(oldName));
+    if (!file.exists())
+        return false;
+    return file.rename(filePath(newName));
+}
+
+DCORE_END_NAMESPACE

--- a/src/filesystem/dcapfsfileengine.cpp
+++ b/src/filesystem/dcapfsfileengine.cpp
@@ -1,0 +1,209 @@
+// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#include "private/dcapfsfileengine_p.h"
+#include "private/dobject_p.h"
+#include "dvtablehook.h"
+
+#include "dcapmanager.h"
+#include <QDebug>
+
+DCORE_BEGIN_NAMESPACE
+
+extern QString _d_cleanPath(const QString &path);
+extern bool _d_isSubFileOf(const QString &filePath, const QString &directoryPath);
+
+static bool capDirIteraterHasNext(QAbstractFileEngineIterator *it)
+{
+    const QStringList &paths = DCapManager::instance()->paths();
+    QString path = it->path();
+    QFileInfo info(path);
+    if (info.isSymLink())
+        info = info.symLinkTarget();
+
+    bool ret = std::any_of(paths.cbegin(), paths.cend(), std::bind(_d_isSubFileOf, path, std::placeholders::_1));
+
+    if (!ret)
+        return ret;
+    return DVtableHook::callOriginalFun(it, &QAbstractFileEngineIterator::hasNext);
+}
+
+QAbstractFileEngine *DCapFSFileEngineHandler::create(const QString &fileName) const
+{
+    return new DCapFSFileEngine(fileName);
+}
+
+
+class DCapFSFileEnginePrivate : public DObjectPrivate
+{
+    D_DECLARE_PUBLIC(DCapFSFileEngine)
+public:
+    DCapFSFileEnginePrivate(const QString &file, DCapFSFileEngine *qq);
+
+    bool canReadWrite(const QString &path) const;
+
+    QString file;
+};
+
+DCapFSFileEnginePrivate::DCapFSFileEnginePrivate(const QString &file, DCapFSFileEngine *qq)
+    : DObjectPrivate(qq)
+    , file(file)
+{
+
+}
+
+bool DCapFSFileEnginePrivate::canReadWrite(const QString &path) const
+{
+    if (path.isEmpty())
+        return false;
+
+    QString target = path;
+    if (path == this->file) {
+        D_QC(DCapFSFileEngine);
+        target = q->fileName(DCapFSFileEngine::AbsoluteName);
+    } else {
+        QFSFileEngine engine(path);
+        target = engine.fileName(DCapFSFileEngine::AbsoluteName);
+    }
+
+    auto paths = DCapManager::instance()->paths();
+    return std::any_of(paths.cbegin(), paths.cend(),
+                       std::bind(_d_isSubFileOf, target, std::placeholders::_1));
+}
+
+DCapFSFileEngine::DCapFSFileEngine(const QString &file)
+    : QFSFileEngine(file)
+    , DObject(*new DCapFSFileEnginePrivate(file, this))
+{
+
+}
+
+DCapFSFileEngine::~DCapFSFileEngine()
+{
+}
+
+bool DCapFSFileEngine::open(QIODevice::OpenMode openMode)
+{
+    D_D(DCapFSFileEngine);
+    if (!d->canReadWrite(d->file))
+        return false;
+    return QFSFileEngine::open(openMode);
+}
+
+bool DCapFSFileEngine::remove()
+{
+    D_D(DCapFSFileEngine);
+    if (!d->canReadWrite(d->file))
+        return false;
+    return QFSFileEngine::remove();
+}
+
+bool DCapFSFileEngine::copy(const QString &newName)
+{
+    D_D(DCapFSFileEngine);
+    if (!d->canReadWrite(newName)) {
+        // ###(Chen Bin): If false is returned here, QFile
+        // will use the interface of qtemporaryfile for
+        // file operation, and the restrictions in
+        // DCapFSFileEngine cannot be used. And it will be
+        // copied successfully.
+        qWarning() << "DCapFSFileEngine: " << QStringLiteral("The file [%1] has no permission to copy!").arg(newName);
+        return true;
+    }
+    return QFSFileEngine::copy(newName);
+}
+
+bool DCapFSFileEngine::rename(const QString &newName)
+{
+    D_D(DCapFSFileEngine);
+    if (!d->canReadWrite(newName))
+        return false;
+    return QFSFileEngine::rename(newName);
+}
+
+bool DCapFSFileEngine::renameOverwrite(const QString &newName)
+{
+    D_D(DCapFSFileEngine);
+    if (!d->canReadWrite(newName))
+        return false;
+    return QFSFileEngine::renameOverwrite(newName);
+}
+
+bool DCapFSFileEngine::link(const QString &newName)
+{
+    D_D(DCapFSFileEngine);
+    if (!d->canReadWrite(newName))
+        return false;
+    return QFSFileEngine::link(newName);
+}
+
+bool DCapFSFileEngine::mkdir(const QString &dirName, bool createParentDirectories) const
+{
+    D_DC(DCapFSFileEngine);
+    if (!d->canReadWrite(dirName))
+        return false;
+    return QFSFileEngine::mkdir(dirName, createParentDirectories);
+}
+
+bool DCapFSFileEngine::rmdir(const QString &dirName, bool recurseParentDirectories) const
+{
+    D_DC(DCapFSFileEngine);
+    if (!d->canReadWrite(dirName))
+        return false;
+    return QFSFileEngine::rmdir(dirName, recurseParentDirectories);
+}
+
+QAbstractFileEngine::FileFlags DCapFSFileEngine::fileFlags(QAbstractFileEngine::FileFlags type) const
+{
+    D_DC(DCapFSFileEngine);
+    FileFlags ret = QFSFileEngine::fileFlags(type);
+    if (ret | ExistsFlag) {
+        if (!d->canReadWrite(d->file)) {
+            ret &= ~ExistsFlag;
+        }
+    }
+
+    return ret;
+}
+
+bool DCapFSFileEngine::cloneTo(QAbstractFileEngine *target)
+{
+    D_DC(DCapFSFileEngine);
+    const QString targetPath = target->fileName(DCapFSFileEngine::AbsolutePathName);
+    if (!d->canReadWrite(targetPath))
+        return false;
+    return QFSFileEngine::cloneTo(target);
+}
+
+bool DCapFSFileEngine::setSize(qint64 size)
+{
+    D_D(DCapFSFileEngine);
+    if (!d->canReadWrite(d->file))
+        return false;
+    return QFSFileEngine::setSize(size);
+}
+
+QStringList DCapFSFileEngine::entryList(QDir::Filters filters, const QStringList &filterNames) const
+{
+    D_DC(DCapFSFileEngine);
+    if (!d->canReadWrite(d->file))
+        return {};
+    return QFSFileEngine::entryList(filters, filterNames);
+}
+
+QAbstractFileEngine::Iterator *DCapFSFileEngine::beginEntryList(QDir::Filters filters, const QStringList &filterNames)
+{
+    auto ret = QFSFileEngine::beginEntryList(filters, filterNames);
+    DVtableHook::overrideVfptrFun(ret, &QAbstractFileEngineIterator::hasNext, &capDirIteraterHasNext);
+    return ret;
+}
+
+bool DCapFSFileEngine::canReadWrite(const QString &path) const
+{
+    D_DC(DCapFSFileEngine);
+    return d->canReadWrite(path);
+}
+
+DCORE_END_NAMESPACE
+

--- a/src/filesystem/dcapmanager.cpp
+++ b/src/filesystem/dcapmanager.cpp
@@ -1,0 +1,152 @@
+// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#include "dcapmanager.h"
+#include "dobject_p.h"
+#include "dstandardpaths.h"
+#include "private/dcapfsfileengine_p.h"
+
+#include <QStandardPaths>
+#include <QDebug>
+
+DCORE_BEGIN_NAMESPACE
+
+QString _d_cleanPath(const QString &path) {
+    return path.size() < 2 || !path.endsWith(QDir::separator()) ? path : path.chopped(1);
+}
+
+bool _d_isSubFileOf(const QString &filePath, const QString &directoryPath)
+{
+    QString path = _d_cleanPath(filePath);
+    bool ret = path.startsWith(directoryPath);
+    return ret;
+}
+
+static QStringList defaultWriteablePaths() {
+    QStringList paths;
+    int list[] = {
+        QStandardPaths::AppConfigLocation, QStandardPaths::AppDataLocation,
+        QStandardPaths::CacheLocation, QStandardPaths::TempLocation,
+        QStandardPaths::DataLocation, QStandardPaths::GenericConfigLocation,
+        QStandardPaths::HomeLocation, QStandardPaths::MusicLocation,
+        QStandardPaths::DocumentsLocation, QStandardPaths::MoviesLocation,
+        QStandardPaths::PicturesLocation, QStandardPaths::DownloadLocation
+    };
+
+    for (uint i = 0; i < sizeof (list) / sizeof (int); ++i) {
+        const QString &path  = QStandardPaths::writableLocation(QStandardPaths::StandardLocation(list[i]));
+        if (path.isEmpty())
+            continue;
+
+        paths.append(path);
+    }
+
+    for (int i = 0; i <= static_cast<int>(DStandardPaths::XDG::RuntimeTime); ++i) {
+        const QString &path = DStandardPaths::path(DStandardPaths::XDG(i));
+        if (path.isEmpty())
+            continue;
+
+        paths.append(path);
+    }
+
+    for (int i = 0; i <= static_cast<int>(DStandardPaths::DSG::DataDir); ++i) {
+        const QStringList &pathList = DStandardPaths::paths(DStandardPaths::DSG(i));
+        if (pathList.isEmpty())
+            continue;
+
+        for (auto path : pathList) {
+            if (path.isEmpty() || paths.contains(path))
+                continue;
+
+            paths.append(path);
+        }
+    }
+    return paths;
+}
+
+static DCapFSFileEngineHandler *globalHandler = nullptr;
+
+class DCapManagerPrivate : public DObjectPrivate
+{
+    D_DECLARE_PUBLIC(DCapManager)
+public:
+    DCapManagerPrivate(DCapManager *qq);
+
+    QStringList pathList;
+};
+
+class DCapManager_ : public DCapManager {};
+Q_GLOBAL_STATIC(DCapManager_, capManager)
+
+DCapManagerPrivate::DCapManagerPrivate(DCapManager *qq)
+    : DObjectPrivate(qq)
+{
+    pathList = defaultWriteablePaths();
+}
+
+DCapManager::DCapManager()
+    : DObject(*new DCapManagerPrivate(this))
+{
+
+}
+
+DCapManager *DCapManager::instance()
+{
+    return capManager;
+}
+
+void DCapManager::registerFileEngine()
+{
+    if (globalHandler)
+        return;
+    globalHandler = new DCapFSFileEngineHandler;
+}
+
+void DCapManager::unregisterFileEngine()
+{
+    if (!globalHandler)
+        return;
+    delete globalHandler;
+    globalHandler = nullptr;
+}
+
+void DCapManager::appendPath(const QString &path)
+{
+    D_D(DCapManager);
+    const QString &targetPath = _d_cleanPath(path);
+    bool exist = std::any_of(d->pathList.cbegin(), d->pathList.cend(),
+                             std::bind(_d_isSubFileOf, targetPath, std::placeholders::_1));
+    if (exist)
+        return;
+    d->pathList.append(targetPath);
+}
+
+void DCapManager::appendPaths(const QStringList &pathList)
+{
+    for (auto path : pathList)
+        appendPath(path);
+}
+
+void DCapManager::removePath(const QString &path)
+{
+    D_D(DCapManager);
+    const QString &targetPath = _d_cleanPath(path);
+    if (!d->pathList.contains(targetPath))
+        return;
+    d->pathList.removeOne(targetPath);
+}
+
+void DCapManager::removePaths(const QStringList &paths)
+{
+    for (auto path : paths)
+        removePath(path);
+}
+
+QStringList DCapManager::paths() const
+{
+    D_DC(DCapManager);
+    return d->pathList;
+}
+
+DCORE_END_NAMESPACE

--- a/src/filesystem/filesystem.cmake
+++ b/src/filesystem/filesystem.cmake
@@ -2,6 +2,7 @@ if(APPLE)
   set(FILESYSTEM_SOURCE 
     ${CMAKE_CURRENT_LIST_DIR}/private/dbasefilewatcher_p.h
     ${CMAKE_CURRENT_LIST_DIR}/private/dfilesystemwatcher_linux_p.h
+    ${CMAKE_CURRENT_LIST_DIR}/private/dcapfsfileengine_p.h
     ${CMAKE_CURRENT_LIST_DIR}/dbasefilewatcher.cpp
     ${CMAKE_CURRENT_LIST_DIR}/dfilesystemwatcher_dummy.cpp
     ${CMAKE_CURRENT_LIST_DIR}/dfilewatcher.cpp
@@ -9,11 +10,15 @@ if(APPLE)
     ${CMAKE_CURRENT_LIST_DIR}/dpathbuf.cpp
     ${CMAKE_CURRENT_LIST_DIR}/dtrashmanager_dummy.cpp
     ${CMAKE_CURRENT_LIST_DIR}/dstandardpaths.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/dcapfile.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/dcapmanager.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/dcapfsfileengine.cpp
   )
 elseif(WIN32)
   set(FILESYSTEM_SOURCE 
     ${CMAKE_CURRENT_LIST_DIR}/private/dbasefilewatcher_p.h
     ${CMAKE_CURRENT_LIST_DIR}/private/dfilesystemwatcher_linux_p.h
+    ${CMAKE_CURRENT_LIST_DIR}/private/dcapfsfileengine_p.h
     ${CMAKE_CURRENT_LIST_DIR}/dbasefilewatcher.cpp
     ${CMAKE_CURRENT_LIST_DIR}/dfilesystemwatcher_win.cpp
     ${CMAKE_CURRENT_LIST_DIR}/dfilewatcher.cpp
@@ -21,18 +26,25 @@ elseif(WIN32)
     ${CMAKE_CURRENT_LIST_DIR}/dpathbuf.cpp
     ${CMAKE_CURRENT_LIST_DIR}/dtrashmanager_dummy.cpp
     ${CMAKE_CURRENT_LIST_DIR}/dstandardpaths.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/dcapfile.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/dcapmanager.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/dcapfsfileengine.cpp
   )
 else()
   set(FILESYSTEM_SOURCE 
     ${CMAKE_CURRENT_LIST_DIR}/private/dbasefilewatcher_p.h
     ${CMAKE_CURRENT_LIST_DIR}/private/dfilesystemwatcher_linux_p.h
+    ${CMAKE_CURRENT_LIST_DIR}/private/dcapfsfileengine_p.h
     ${CMAKE_CURRENT_LIST_DIR}/dbasefilewatcher.cpp
     ${CMAKE_CURRENT_LIST_DIR}/dfilesystemwatcher_linux.cpp
     ${CMAKE_CURRENT_LIST_DIR}/dfilewatcher.cpp
     ${CMAKE_CURRENT_LIST_DIR}/dfilewatchermanager.cpp
     ${CMAKE_CURRENT_LIST_DIR}/dpathbuf.cpp
     ${CMAKE_CURRENT_LIST_DIR}/dtrashmanager_linux.cpp
-  	${CMAKE_CURRENT_LIST_DIR}/dstandardpaths.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/dstandardpaths.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/dcapfile.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/dcapmanager.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/dcapfsfileengine.cpp
   )
 endif()
 file(GLOB FILESYSTEM_HEAD

--- a/src/filesystem/filesystem.pri
+++ b/src/filesystem/filesystem.pri
@@ -1,0 +1,55 @@
+include($$PWD/private/private.pri)
+
+INCLUDEPATH += $$PWD/../base
+
+INSTALL_PREFIX=$$QT_INSTALL_PREFIX
+isEmpty(INSTALL_PREFIX): INSTALL_PREFIX=$$[QT_INSTALL_PREFIX]
+DEFINES += PREFIX=\\\"$$INSTALL_PREFIX\\\"
+
+HEADERS += \
+    $$PWD/dbasefilewatcher.h \
+    $$PWD/dcapmanager.h \
+    $$PWD/dfilesystemwatcher.h \
+    $$PWD/dfilewatcher.h \
+    $$PWD/dfilewatchermanager.h \
+    $$PWD/dpathbuf.h \
+    $$PWD/dstandardpaths.h \
+    $$PWD/dtrashmanager.h \
+    $$PWD/dcapfile.h \
+
+SOURCES += \
+    $$PWD/dbasefilewatcher.cpp \
+    $$PWD/dcapmanager.cpp \
+    $$PWD/dfilewatcher.cpp \
+    $$PWD/dfilewatchermanager.cpp \
+    $$PWD/dstandardpaths.cpp \
+    $$PWD/dpathbuf.cpp \
+    $$PWD/dcapfsfileengine.cpp \
+    $$PWD/dcapfile.cpp \
+
+linux {
+    SOURCES += \
+        $$PWD/dfilesystemwatcher_linux.cpp \
+        $$PWD/dtrashmanager_linux.cpp
+} else:win* {
+    SOURCES += \
+        $$PWD/dfilesystemwatcher_win.cpp \
+        $$PWD/dtrashmanager_dummy.cpp
+} else {
+    SOURCES += \
+        $$PWD/dfilesystemwatcher_dummy.cpp \
+        $$PWD/dtrashmanager_dummy.cpp
+}
+
+includes.files += $$PWD/*.h
+includes.files += \
+    $$PWD/DFileWatcher \
+    $$PWD/DBaseFileWatcher \
+    $$PWD/DCapManager \
+    $$PWD/DCapFile \
+    $$PWD/DCapDir \
+    $$PWD/DFileSystemWatcher \
+    $$PWD/DFileWatcherManager \
+    $$PWD/DPathBuf \
+    $$PWD/DStandardPaths \
+    $$PWD/DTrashManager \

--- a/src/filesystem/private/dcapfsfileengine_p.h
+++ b/src/filesystem/private/dcapfsfileengine_p.h
@@ -1,0 +1,46 @@
+// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#ifndef DCAPFSFILEENGINE_P_H
+#define DCAPFSFILEENGINE_P_H
+
+#include <DObject>
+
+#include <private/qfsfileengine_p.h>
+
+DCORE_BEGIN_NAMESPACE
+
+class DCapFSFileEngineHandler : public QAbstractFileEngineHandler
+{
+public:
+    QAbstractFileEngine *create(const QString &fileName) const override;
+};
+
+class DCapFSFileEnginePrivate;
+class DCapFSFileEngine : public QFSFileEngine, public DObject
+{
+    D_DECLARE_PRIVATE(DCapFSFileEngine);
+public:
+    DCapFSFileEngine(const QString &file);
+    ~DCapFSFileEngine() override;
+
+    bool open(QIODevice::OpenMode openMode) override;
+    bool remove() override;
+    bool copy(const QString &newName) override;
+    bool rename(const QString &newName) override;
+    bool renameOverwrite(const QString &newName) override;
+    bool link(const QString &newName) override;
+    bool mkdir(const QString &dirName, bool createParentDirectories) const override;
+    bool rmdir(const QString &dirName, bool recurseParentDirectories) const override;
+    FileFlags fileFlags(FileFlags type) const override;
+    bool cloneTo(QAbstractFileEngine *target) override;
+    bool setSize(qint64 size) override;
+    QStringList entryList(QDir::Filters filters, const QStringList &filterNames) const override;
+    Iterator *beginEntryList(QDir::Filters filters, const QStringList &filterNames) override;
+
+    bool canReadWrite(const QString &path) const;
+};
+
+DCORE_END_NAMESPACE
+#endif // DCAPFSFILEENGINE_P_H

--- a/src/filesystem/private/private.pri
+++ b/src/filesystem/private/private.pri
@@ -1,0 +1,11 @@
+HEADERS += \
+    $$PWD/dbasefilewatcher_p.h \
+    $$PWD/dcapfsfileengine_p.h
+
+linux {
+    HEADERS += \
+        $$PWD/dfilesystemwatcher_linux_p.h
+} else:win* {
+    HEADERS += \
+        $$PWD/dfilesystemwatcher_win_p.h
+}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -113,6 +113,7 @@ target_link_libraries(
     ../include/settings/
     ../include/filesystem/
     ../include/
+    ../src/filesystem/private/
   )
 else()
   add_executable(${LIBNAME}

--- a/tests/ut_dcapfile.cpp
+++ b/tests/ut_dcapfile.cpp
@@ -1,0 +1,318 @@
+// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#include "dcapfsfileengine_p.h"
+#include "filesystem/dcapmanager.h"
+#include "filesystem/dcapfile.h"
+
+#include <gtest/gtest.h>
+#include <QDir>
+#include <QDir>
+#include <QTemporaryDir>
+
+DCORE_USE_NAMESPACE
+
+#ifndef GTEST_SKIP
+#define SKIP return GTEST_SUCCEED() << "Skip all tests"
+#else
+#define SKIP GTEST_SKIP() << "Skip all tests"
+#endif
+
+#define TMPCAP_PATH "/tmp/cap"
+
+class ut_DCapFSFileEngine : public testing::Test
+{
+protected:
+    void SetUp() override;
+    void TearDown() override;
+
+    DCapManager *manager;
+    QFile *file;
+};
+
+void ut_DCapFSFileEngine::SetUp()
+{
+     manager = DCapManager::instance();
+     manager->removePath("/tmp");
+     manager->appendPath(TMPCAP_PATH);
+     manager->registerFileEngine();
+
+     file = new QFile(nullptr);
+     QDir dir(TMPCAP_PATH);
+     if (!dir.exists())
+         ASSERT_TRUE(dir.mkdir(TMPCAP_PATH));
+}
+
+void ut_DCapFSFileEngine::TearDown()
+{
+    manager->unregisterFileEngine();
+    manager->appendPath("/tmp");
+    delete file;
+    QDir dir(TMPCAP_PATH);
+    if (dir.exists())
+        ASSERT_TRUE(dir.removeRecursively());
+}
+
+TEST_F(ut_DCapFSFileEngine, testSubDirCanReadWrite)
+{
+    manager->appendPath("/usr/share/");
+    ASSERT_FALSE(DCapFSFileEngine("").canReadWrite("/tmp/usr/share/file0"));
+    manager->removePath("/usr/share/");
+}
+
+TEST_F(ut_DCapFSFileEngine, testDCapFileOpenFile)
+{
+    file->setFileName("/tmp/file0");
+    bool open = file->open(QIODevice::WriteOnly);
+    ASSERT_FALSE(open);  // path `/tmp` has removed from setup.
+
+    QDir dir(TMPCAP_PATH);
+    ASSERT_TRUE(dir.exists());
+    if (!dir.exists("subdir"))
+        ASSERT_TRUE(dir.mkdir("subdir"));
+    ASSERT_TRUE(dir.cd("subdir"));
+    file->close();
+    file->setFileName(dir.path() + "/file0");  // path: /tmp/etc/subdir/file0
+    ASSERT_TRUE(file->open(QIODevice::WriteOnly));
+}
+
+TEST_F(ut_DCapFSFileEngine, testDCapFileRename)
+{
+    file->setFileName(TMPCAP_PATH"/file0");
+    bool open = file->open(QIODevice::WriteOnly);
+    ASSERT_TRUE(open);  // Default path contains the `/tmp` path.
+    file->close();
+
+    ASSERT_TRUE(file->rename(TMPCAP_PATH"/file1"));
+    ASSERT_FALSE(file->rename("/tmp/file1"));
+
+    QDir dir(TMPCAP_PATH);
+    if (!dir.exists("subdir"))
+        ASSERT_TRUE(dir.mkdir("subdir"));
+    ASSERT_TRUE(file->rename(TMPCAP_PATH"/subdir/file0"));
+}
+
+TEST_F(ut_DCapFSFileEngine, testDCapFileRemove)
+{
+    file->setFileName(TMPCAP_PATH"/test");
+    ASSERT_TRUE(file->open(QFile::WriteOnly));
+    file->close();
+    ASSERT_TRUE(file->exists());
+    ASSERT_TRUE(file->remove());
+    ASSERT_FALSE(file->exists());
+
+    QDir dir(TMPCAP_PATH);
+    if (!dir.exists("subdir"))
+        ASSERT_TRUE(dir.mkdir("subdir"));
+
+    manager->appendPath(TMPCAP_PATH"/subdir");  // create a new subdir file.
+    ASSERT_FALSE(manager->paths().contains(TMPCAP_PATH"/subdir"));  // already has /tmp/cap
+    QFile f(TMPCAP_PATH"/subdir/test");
+    ASSERT_TRUE(f.open(QFile::WriteOnly));
+    f.close();
+    ASSERT_TRUE(f.exists());
+
+    file->setFileName(TMPCAP_PATH"/subdir/test");
+    ASSERT_TRUE(file->remove());
+
+    manager->appendPath("/tmp");
+    ASSERT_TRUE(manager->paths().contains("/tmp"));
+    file->setFileName("/tmp/file0");
+    bool open = file->open(QIODevice::WriteOnly);
+    ASSERT_TRUE(open);
+    manager->removePath("/tmp");
+    ASSERT_FALSE(manager->paths().contains("/tmp"));
+    ASSERT_FALSE(file->remove());
+}
+
+TEST_F(ut_DCapFSFileEngine, testDCapFileLink)
+{
+    file->setFileName(TMPCAP_PATH"/test");
+    ASSERT_TRUE(file->open(QFile::WriteOnly));
+    file->close();
+    ASSERT_TRUE(file->exists());
+    ASSERT_TRUE(file->link(TMPCAP_PATH"/test1"));
+    ASSERT_FALSE(file->link("/tmp/test1"));
+
+    QDir dir(TMPCAP_PATH);
+    if (!dir.exists("subdir"))
+        ASSERT_TRUE(dir.mkdir("subdir"));
+    ASSERT_TRUE(file->link(TMPCAP_PATH"/subdir/test1"));
+
+    ASSERT_TRUE(file->remove());  // clean the file.
+}
+
+TEST_F(ut_DCapFSFileEngine, testDCapFileCopy)
+{
+    file->setFileName(TMPCAP_PATH"/test");
+    ASSERT_TRUE(file->open(QFile::WriteOnly));
+    file->write("test");
+    file->close();
+    ASSERT_TRUE(file->exists());
+    ASSERT_TRUE(file->copy(TMPCAP_PATH"/test2"));
+    ASSERT_TRUE(file->copy("/tmp/test2"));
+    ASSERT_FALSE(QFileInfo::exists(TMPCAP_PATH"/subdir/test2"));
+
+    QDir dir(TMPCAP_PATH);
+    if (!dir.exists("subdir"))
+        ASSERT_TRUE(dir.mkdir("subdir"));
+    ASSERT_TRUE(file->copy(TMPCAP_PATH"/subdir/test2"));
+    ASSERT_TRUE(QFileInfo::exists(TMPCAP_PATH"/subdir/test2"));
+}
+
+TEST_F(ut_DCapFSFileEngine, testDCapFileResize)
+{
+    file->setFileName(TMPCAP_PATH"/test");
+    ASSERT_TRUE(file->open(QFile::WriteOnly));
+    file->write("test");
+    file->close();
+    ASSERT_TRUE(file->exists());
+    ASSERT_TRUE(file->resize(10));
+    ASSERT_EQ(file->size(), 10);
+
+    QDir dir(TMPCAP_PATH);
+    if (!dir.exists("subdir"))
+        ASSERT_TRUE(dir.mkdir("subdir"));
+
+    QFile f(TMPCAP_PATH"/subdir/test");
+    ASSERT_TRUE(f.open(QFile::WriteOnly));
+    f.write("test");
+    f.close();
+    ASSERT_TRUE(f.exists());
+
+    file->setFileName(TMPCAP_PATH"/subdir/test");
+    ASSERT_TRUE(file->resize(10));
+
+    DCapManager::instance()->appendPath("/tmp");
+
+    f.setFileName("/tmp/test");
+    ASSERT_TRUE(f.open(QFile::WriteOnly));
+    f.write("test");
+    f.close();
+    ASSERT_TRUE(f.exists());
+    DCapManager::instance()->removePath("/tmp");
+
+    file->setFileName("/tmp/test");
+    ASSERT_FALSE(file->resize(10));
+    file->remove();}
+
+TEST_F(ut_DCapFSFileEngine, testDCapDirEntry)
+{
+    auto createFiles = [this](const QString & path, int count) {
+        for (int i = 0; i < count; ++i) {
+            file->setFileName(QString(path) + "/test" + QString::number(i));
+            ASSERT_TRUE(file->open(QFile::WriteOnly));
+            file->close();
+            ASSERT_TRUE(file->exists());
+        }
+    };
+
+    createFiles(TMPCAP_PATH, 10);
+    QDir dir(TMPCAP_PATH);
+    ASSERT_TRUE(dir.entryList(QDir::Files).length() == 10);
+
+    if (!dir.exists("subdir"))
+        ASSERT_TRUE(dir.mkdir("subdir"));
+
+    dir.setPath(TMPCAP_PATH"/subdir");
+    createFiles(TMPCAP_PATH"/subdir", 10);
+    ASSERT_TRUE(dir.entryList(QDir::Files).length() == 10);
+    manager->removePath(TMPCAP_PATH);
+    ASSERT_TRUE(dir.entryList(QDir::Files).length() == 0);
+}
+
+TEST(ut_DCapFileAndDir, testDCapFileOpen)
+{
+    DCapFile file("/tmp/test0");
+    ASSERT_TRUE(file.open(DCapFile::WriteOnly));  // Default, '/tmp' is allowable for writing.
+    file.close();
+
+    DCapManager::instance()->removePath("/tmp");
+    ASSERT_FALSE(file.open(DCapFile::WriteOnly));
+    DCapManager::instance()->appendPath("/tmp");
+}
+
+TEST(ut_DCapFileAndDir, testDCapFileOperation)
+{
+    auto CheckResult = [](bool result) {
+        DCapFile file("/tmp/test0");
+        ASSERT_EQ(file.open(DCapFile::WriteOnly), result);
+        file.close();
+
+        ASSERT_EQ(file.exists(), result);
+        ASSERT_EQ(DCapFile::exists(file.fileName()), result);
+        ASSERT_EQ(file.remove(), result);
+
+        ASSERT_EQ(file.open(DCapFile::WriteOnly), result);
+        file.close();
+        ASSERT_EQ(DCapFile::remove(file.fileName()), result);
+
+        ASSERT_EQ(file.open(DCapFile::WriteOnly), result);
+        file.close();
+        ASSERT_EQ(file.rename("/tmp/test1"), result);
+        ASSERT_EQ(DCapFile::rename(file.fileName(), "/tmp/test0"), result);
+
+        file.setFileName("/tmp/test0");
+        ASSERT_EQ(file.link("/tmp/test_link0"), result);
+        ASSERT_EQ(DCapFile::link(file.fileName(), "/tmp/test_link1"), result);
+        ASSERT_EQ(DCapFile::remove("/tmp/test_link0"), result);
+        ASSERT_EQ(DCapFile::remove("/tmp/test_link1"), result);
+
+        file.setFileName("/tmp/test0");
+        ASSERT_EQ(file.copy("/tmp/test_copy0"), result);
+        ASSERT_EQ(DCapFile::copy(file.fileName(), "/tmp/test_copy1"), result);
+        ASSERT_EQ(DCapFile::remove("/tmp/test_copy0"), result);
+        ASSERT_EQ(DCapFile::remove("/tmp/test_copy1"), result);
+
+        ASSERT_EQ(file.resize(10), result);
+        ASSERT_EQ(file.size() == 10, result);
+        ASSERT_EQ(DCapFile::resize(file.fileName(), 5), result);
+        ASSERT_EQ(file.size() == 5, result);
+        ASSERT_EQ(file.remove(), result);
+    };
+
+    CheckResult(true);
+    DCapManager::instance()->removePath("/tmp");
+    CheckResult(false);
+    DCapManager::instance()->appendPath("/tmp");
+}
+
+TEST(ut_DCapFileAndDir, testDCapDirOperation)
+{
+    DCapDir dir("/tmp");
+    ASSERT_TRUE(dir.exists());
+    ASSERT_FALSE(dir.entryList().isEmpty());
+    ASSERT_FALSE(dir.entryInfoList().isEmpty());
+
+    DCapFile file(dir.path() + "/test0");
+    ASSERT_TRUE(file.open(DCapFile::WriteOnly));
+    file.close();
+    ASSERT_TRUE(dir.exists("test0"));
+
+    ASSERT_TRUE(dir.mkdir("cap"));
+    ASSERT_TRUE(dir.exists("cap"));
+    ASSERT_TRUE(dir.rmdir("cap"));
+    ASSERT_FALSE(dir.exists("cap"));
+
+    dir.mkdir("cap");
+    ASSERT_TRUE(dir.cd("cap"));
+    ASSERT_TRUE(dir.exists());
+    DCapManager::instance()->removePath("/tmp");
+    DCapManager::instance()->appendPath(dir.path());
+    ASSERT_FALSE(dir.cd(".."));
+    dir.setPath("/tmp");
+
+    ASSERT_TRUE(dir.entryList().isEmpty());
+    ASSERT_TRUE(dir.entryInfoList().isEmpty());
+    ASSERT_TRUE(dir.exists("cap"));
+    ASSERT_FALSE(dir.remove("test0"));
+    ASSERT_FALSE(dir.rename("test0", "test1"));
+
+    ASSERT_TRUE(dir.mkpath(TMPCAP_PATH"/subdir"));
+    ASSERT_TRUE(dir.rmpath(TMPCAP_PATH"/subdir"));
+
+    DCapManager::instance()->appendPath("/tmp");
+    ASSERT_TRUE(dir.rename("test0", "test1"));
+    ASSERT_TRUE(dir.remove("test1"));
+}


### PR DESCRIPTION
Use DCapManager class to unify privilege management on
whether to open files or not.

By registering a special file engine, the scope of action
after registration is global unless called the unregister
function manually.

By default, the application can still access some directories
and files with permissions after it is started, but when it
access files beyond the scope of these directories, it will
not get any information.

The default directory includes: Home path; Cache path; DSG path
XDG path etc.

Log:
Influence: null
Change-Id: I0fed6051addc56001b382fc34f73b046c0e4aca2