### PR TITLE
fix: fallback to the user directory if no a valid global config direc…

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -18,7 +18,7 @@ endif
 	dh $@ --buildsystem=qmake --parallel
 
 override_dh_auto_configure:
-	dh_auto_configure -- LIB_INSTALL_DIR=/usr/lib/$(DEB_HOST_MULTIARCH) VERSION=$(CONFIG_VERSION)
+	dh_auto_configure -- LIB_INSTALL_DIR=/usr/lib/$(DEB_HOST_MULTIARCH) VERSION=$(CONFIG_VERSION) D_DSG_APP_DATA_FALLBACK=/var/dsg/appdata
 
 #override_dh_auto_test:
 #	echo "skip auto test"

--- a/src/src.pro
+++ b/src/src.pro
@@ -26,6 +26,8 @@ SOURCES += \
     dtkcore_global.cpp
 
 linux: {
+    !isEmpty(D_DSG_APP_DATA_FALLBACK): DEFINES += D_DSG_APP_DATA_FALLBACK=\\\"$$D_DSG_APP_DATA_FALLBACK\\\"
+
     HEADERS += \
         $$PWD/dconfigfile.h
 

--- a/tests/tests.pro
+++ b/tests/tests.pro
@@ -64,6 +64,8 @@ SOURCES += $$PWD/*.cpp \
     $$PWD/../src/dsgapplication.cpp
 
 linux: {
+    !isEmpty(D_DSG_APP_DATA_FALLBACK): DEFINES += D_DSG_APP_DATA_FALLBACK=\\\"$$D_DSG_APP_DATA_FALLBACK\\\"
+
     HEADERS += \
         $$PWD/../src/dconfigfile.h
 


### PR DESCRIPTION
…tory

In the not supported for DSG_APP_DATA environment, we can't get a valid
directory for the global config, then falied when saving data. In order
not to lose data, we can only fallback to storing it to the user
directory.

Log: