### PR TITLE
Fix: link to dl

### DIFF
--- a/src/src.pro
+++ b/src/src.pro
@@ -77,6 +77,7 @@ includes.files += \
 
 DTK_MODULE_NAME = $$TARGET
 load(dtk_build)
+LIBS += -ldl
 
 INSTALLS += includes target
 


### PR DESCRIPTION
It should link to dl for some distrbutions. For example, openSUSE.
The compiling won't be success without this link.

log: