### PR TITLE
fix(build): invalid digit "8" in octal constant

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -7,7 +7,8 @@ DEB_HOST_MULTIARCH ?= $(shell dpkg-architecture -qDEB_HOST_MULTIARCH)
 
 VERSION = $(DEB_VERSION_UPSTREAM)
 PACK_VER = $(shell echo $(VERSION) | awk -F'[+_~-]' '{print $$1}')
-BUILD_VER = $(shell echo $(VERSION) | awk -F'[+_~-]' '{print $$2}' | sed 's/[^0-9]//g')
+# Fix: invalid digit "8" in octal constant. e.g.  u008 ==> 008 ==> 8
+BUILD_VER = $(shell echo $(VERSION) | awk -F'[+_~-]' '{print $$2}' | sed 's/[^0-9]//g') | awk '{print int($$1)}'
 
 
 %:


### PR DESCRIPTION
when BUILD_VERSION start with 0 was recognized as octal

Log:
Influence: debian build
Change-Id: I0d9cb1518b4250b5f50408651d8fab66f469bebb