### PR TITLE
fix: missing include folder while generating documentation

### DIFF
--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -7,7 +7,7 @@ set (QCH_INSTALL_DESTINATION ${CMAKE_INSTALLL_PREFIX}/share/DDE/dtk CACHE STRING
 set (DOXYGEN_GENERATE_HTML "NO" CACHE STRING "Doxygen HTML output")
 set (DOXYGEN_GENERATE_XML "NO" CACHE STRING "Doxygen XML output")
 set (DOXYGEN_GENERATE_QHP "YES" CACHE STRING "Doxygen QHP output")
-set (DOXYGEN_FILE_PATTERNS *.cpp *.h *.md *.zh_CN.dox CACHE STRING "Doxygen File Patterns")
+set (DOXYGEN_FILE_PATTERNS *.cpp *.h *.zh_CN.md *.zh_CN.dox CACHE STRING "Doxygen File Patterns")
 set (DOXYGEN_PROJECT_NUMBER ${CMAKE_PROJECT_VERSION} CACHE STRING "") # Should be the same as this project is using.
 set (DOXYGEN_EXTRACT_STATIC YES)
 set (DOXYGEN_OUTPUT_LANGUAGE "Chinese")
@@ -22,13 +22,14 @@ set (DOXYGEN_TAGFILES "qtcore.tags=qthelp://org.qt-project.qtcore/qtcore/" CACHE
 set (DOXYGEN_PREDEFINED
     "\"DCORE_BEGIN_NAMESPACE=namespace Dtk { namespace Core {\""
     "\"DCORE_END_NAMESPACE=}}\""
-    "\"DCORE_USE_NAMESPACE=using Dtk::Core\""
+    "\"DCORE_USE_NAMESPACE=using namespace Dtk::Core\;\""
 )
 set (DOXYGEN_MACRO_EXPANSION "YES")
 set (DOXYGEN_EXPAND_ONLY_PREDEF "YES")
 
 doxygen_add_docs (doxygen
     ${PROJECT_SOURCE_DIR}/src
+    ${PROJECT_SOURCE_DIR}/include
     ${PROJECT_SOURCE_DIR}/doc
     ALL
     WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}


### PR DESCRIPTION
处理了两个问题：

1. 错误的宏预定义配置
2. 项目整体改 CMake 后，遗漏的 include 目录

此修改后，可重新使类如 DConfig 之类的文档正常生成内容，且位于正确的名称空间内。