### PR TITLE
fix: Build failed using clang

### DIFF
--- a/include/util/dasync.h
+++ b/include/util/dasync.h
@@ -48,7 +48,7 @@ namespace DtkCorePrivate
             return QQueue<T>::head();
         }
     private:
-        QMutex m_mtx;
+        mutable QMutex m_mtx;
     };
 
     // 内部使用，不对外提供接口


### PR DESCRIPTION
const 类成员函数下的成员变量默认会添加 const 属性，
而 QMutexLocker 的参数需要接收一个非 const 的变量，
出现编译错误。这种情况下，需要将成员变量修改为
mutable。

Log:
Change-Id: I573b3a258a837037717b9d646977886dba45c5d8