### PR TITLE
chore: Modify some nonstandard writing

### DIFF
--- a/src/dconfig.cpp
+++ b/src/dconfig.cpp
@@ -267,7 +267,7 @@ public:
             qCWarning(cfLog, "Can't acquire config manager. error:\"%s\"", qPrintable(dbus_reply.error().message()));
             return false;
         } else {
-            qCWarning(cfLog(), "dbus path=\"%s\"", qPrintable(dbus_path.path()));
+            qCDebug(cfLog(), "dbus path=\"%s\"", qPrintable(dbus_path.path()));
             config.reset(new DSGConfigManager(DSG_CONFIG_MANAGER, dbus_path.path(),
                                                 QDBusConnection::systemBus(), owner->q_func()));
             if (!config->isValid()) {

--- a/src/dconfigfile.cpp
+++ b/src/dconfigfile.cpp
@@ -136,7 +136,7 @@ static DConfigFile::Version parseVersion(const QJsonObject &obj) {
 #define MAGIC_OVERRIDE QLatin1String("dsg.config.override")
 #define MAGIC_CACHE QLatin1String("dsg.config.cache")
 
-static const uint GlobalUID = 0xFFFF;
+static const uint InvalidUID = 0xFFFF;
 
 inline static bool checkMagic(const QJsonObject &obj, QLatin1String request) {
     return obj[QLatin1String("magic")].toString() == request;
@@ -1020,6 +1020,7 @@ public:
         values.setTime(key, QDateTime::currentDateTime().toString(Qt::ISODate));
         values.setUser(key, uid);
         values.setAppId(key, appid.isEmpty() ? configKey.appId : appid);
+        cacheChanged = true;
         return true;
     }
 
@@ -1034,7 +1035,7 @@ public:
     DConfigInfo values;
     uint userid;
     bool global;
-    char padding [3] = {};
+    bool cacheChanged = false;
 };
 
 DConfigCacheImpl::DConfigCacheImpl(const DConfigKey &configKey, const uint uid, bool global)
@@ -1086,6 +1087,9 @@ bool DConfigCacheImpl::load(const QString &localPrefix)
 
 bool DConfigCacheImpl::save(const QString &localPrefix, QJsonDocument::JsonFormat format, bool sync)
 {
+    if (!cacheChanged)
+        return true;
+
     const QString &dir = getCacheDir(localPrefix);
     if (dir.isEmpty()) {
         qCWarning(cfLog, "Falied on saveing, the config cache directory is empty for the user[%d], "
@@ -1244,14 +1248,14 @@ DConfigFile::DConfigFile(const QString &appId, const QString &name, const QStrin
     Q_ASSERT(!name.isEmpty());
 
     D_D(DConfigFile);
-    d->globalCache = new DConfigCacheImpl(d->configKey, GlobalUID, true);
+    d->globalCache = new DConfigCacheImpl(d->configKey, InvalidUID, true);
 }
 
 DConfigFile::DConfigFile(const DConfigFile &other)
     : DObject(*new DConfigFilePrivate(this, other.d_func()->configKey))
 {
     D_D(DConfigFile);
-    auto cache = new DConfigCacheImpl(d->configKey, GlobalUID, true);
+    auto cache = new DConfigCacheImpl(d->configKey, InvalidUID, true);
     cache->values = other.d_func()->globalCache->values;
     d->globalCache = cache;
 }


### PR DESCRIPTION
  Change Warning log to Debug.
  Rename GlobalUID to InvalidUID avoiding to misunderstand.
  cache saved only it's setValue has been called.

Log: 移除错误的输出警告，当cache被修改后才保存
Influence: 如果没有设置值，再不会生成缓存文件
Change-Id: I1f71513e91bef3412f593281e68fea44801fe07b