### PR TITLE
chore: Modify some nonstandard writing

### DIFF
--- a/src/dconfig.cpp
+++ b/src/dconfig.cpp
@@ -286,7 +286,7 @@ public:
             qCWarning(cfLog, "Can't acquire config manager. error:\"%s\"", qPrintable(dbus_reply.error().message()));
             return false;
         } else {
-            qCWarning(cfLog(), "dbus path=\"%s\"", qPrintable(dbus_path.path()));
+            qCDebug(cfLog(), "dbus path=\"%s\"", qPrintable(dbus_path.path()));
             config.reset(new DSGConfigManager(DSG_CONFIG_MANAGER, dbus_path.path(),
                                                 QDBusConnection::systemBus(), owner->q_func()));
             if (!config->isValid()) {


### PR DESCRIPTION
  Change Warning log to Debug.
  Rename GlobalUID to InvalidUID avoiding to misunderstand.
  cache saved only it's setValue has been called.

Log: 移除错误的输出警告，当cache被修改后才保存
Influence: 如果没有设置值，再不会生成缓存文件
Change-Id: I1f71513e91bef3412f593281e68fea44801fe07b