### PR TITLE
fix: wrong option() usage in CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,22 +1,13 @@
 cmake_minimum_required (VERSION 3.10)
 
-option(DVERSION "define project version" "5.5.22")
-if(DVERSION)
-  project (DtkCore
-    VERSION ${DVERSION}
-    DESCRIPTION "DTK Core module"
-    HOMEPAGE_URL "https://github.com/linuxdeepin/dtkcore"
-    LANGUAGES CXX C
-  )
-else()
-  project (DtkCore
-    #VERSION "${DTK_REPO_MODULE_VERSION}"
-    VERSION "5.5.23"
-    DESCRIPTION "DTK Core module"
-    HOMEPAGE_URL "https://github.com/linuxdeepin/dtkcore"
-    LANGUAGES CXX C
-  )
-endif()
+set (DVERSION "5.6.0.2" CACHE STRING "define project version")
+
+project (DtkCore
+  VERSION ${DVERSION}
+  DESCRIPTION "DTK Core module"
+  HOMEPAGE_URL "https://github.com/linuxdeepin/dtkcore"
+  LANGUAGES CXX C
+)
 message(STATUS ${PROJECT_VERSION})
 include(GNUInstallDirs)
 set (BUILD_EXAMPLES ON CACHE BOOL "Build examples")
@@ -25,7 +16,6 @@ if(NOT BUILD_VERSION)
   set(BUILD_VERSION "0")
 endif()
 
-find_package (Qt5 CONFIG REQUIRED COMPONENTS DBus Xml)
 if(UNIX AND NOT APPLE)
   set(LINUX TRUE)
 endif()


### PR DESCRIPTION
修复错误的 `option()` 用法。

Review 的时候有一些细节要注意，可能也待讨论：

1. 原本用的 `DVERSION` 是故意的？如果希望外部通过 `-DVERSION` 参数来修改的话，变量名应该是 `VERSION` 才对。
2. 与版本号相关，看到定义了一个单独的 `BUILD_VERSION`，目的是什么？如果是第四位版本号的话，为什么不直接用 [`PROJECT_VERSION_TWEAK`](https://cmake.org/cmake/help/latest/variable/PROJECT_VERSION_TWEAK.html#variable:PROJECT_VERSION_TWEAK)？

当然目前看这个 CMakeLists.txt 还有一些别的问题，就不在这个 PR 里讨论了。

此 PR 讨论结束并合入后，其他 DTK 组件也需要进行相应的调整。