### PR TITLE
fix: don't check DtkCore_TOOL_DIR cause split pkgs

### DIFF
--- a/misc/DtkConfig.cmake.in
+++ b/misc/DtkConfig.cmake.in
@@ -1,7 +1,7 @@
 @PACKAGE_INIT@
 
 set_and_check(DtkCore_INCLUDE_DIR "@PACKAGE_INCLUDE_INSTALL_DIR@")
-set_and_check(DtkCore_TOOL_DIR "@PACKAGE_TOOL_INSTALL_DIR@")
+set(DtkCore_TOOL_DIR "@PACKAGE_TOOL_INSTALL_DIR@")
 set(DtkCore_LIBRARIES dtkcore)
 include_directories("${DtkCore_INCLUDE_DIR}")
 


### PR DESCRIPTION
Log： deepin 中，tool 会被分到和 dev 不同的 bin 包，因此 dev 提供的 config.cmake  不应该检查 DtkCore_TOOL_DIR 是否存在