### PR TITLE
chore: add CMake rules for installing dexpected.h

### DIFF
--- a/include/DtkCore/DError
+++ b/include/DtkCore/DError
@@ -1,0 +1,1 @@
+#include "derror.h"

--- a/include/DtkCore/DExpected
+++ b/include/DtkCore/DExpected
@@ -1,0 +1,1 @@
+#include "dexpected.h"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -104,6 +104,8 @@ set(TOINSTALLBASE
   ../include/base/dobject.h
   ../include/base/dsingleton.h
   ../include/base/private/dobject_p.h
+  ../include/base/derror.h
+  ../include/base/dexpected.h
 )
 install(FILES ${TOINSTALLBASE} DESTINATION "${INCLUDE_INSTALL_DIR}")
 install(DIRECTORY ../include/dci/ DESTINATION "${INCLUDE_INSTALL_DIR}" FILES_MATCHING PATTERN "*.h")

--- a/src/base/base.cmake
+++ b/src/base/base.cmake
@@ -2,5 +2,7 @@ set(base_SRCS
   ${CMAKE_CURRENT_LIST_DIR}/../../include/base/dobject.h
   ${CMAKE_CURRENT_LIST_DIR}/../../include/base/private/dobject_p.h
   ${CMAKE_CURRENT_LIST_DIR}/../../include/base/dsingleton.h
+  ${CMAKE_CURRENT_LIST_DIR}/../../include/base/dexpected.h
+  ${CMAKE_CURRENT_LIST_DIR}/../../include/base/derror.h
   ${CMAKE_CURRENT_LIST_DIR}/dobject.cpp
 )


### PR DESCRIPTION
以及derror.h

Log: 添加dexpected.h的CMake安装规则