### PR TITLE
fix: missingdefinition

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -10,6 +10,7 @@ set(CMAKE_AUTORCC ON)
 
 set (DSG_PREFIX_PATH "${CMAKE_INSTALL_PREFIX}" CACHE STRING "PREFIX of DSG_DATA_DIRS")
 add_definitions(-DPREFIX="${DSG_PREFIX_PATH}")
+add_definitions(-DLIBDTKCORE_LIBRARY)
 find_package(Qt5 REQUIRED COMPONENTS Core)
 if(LINUX)
 find_package(PkgConfig REQUIRED)


### PR DESCRIPTION
the first time turn to cmake, the definition is missing

Log: return the missingdefinition
