### PR TITLE
fix: Logger constructor crash

### DIFF
--- a/src/log/Logger.cpp
+++ b/src/log/Logger.cpp
@@ -581,10 +581,8 @@ Logger::Logger()
   \sa setDefaultCategory()
  */
 Logger::Logger(const QString &defaultCategory)
+    :Logger()
 {
-    Q_D(Logger);
-    d->logDevice = new LogDevice(this);
-
     setDefaultCategory(defaultCategory);
 }
 


### PR DESCRIPTION
LoggerPrivate not init..

Log: 修复帮助手册在升级dtkcore后无法打开的问题
Bug: https://pms.uniontech.com/bug-view-172121.html
Change-Id: Ieee74154a33260043af264a176dabc672a17f559