### PR TITLE
chore: fix license

### DIFF
--- a/include/log/win32/OutputDebugAppender.h
+++ b/include/log/win32/OutputDebugAppender.h
@@ -1,4 +1,3 @@
-// SPDX-FileCopyrightText: 2010 Karl-Heinz Reichel (khreichel at googlemail dot com)
 // SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later


### PR DESCRIPTION
fix license in win32/OutputDebugAppender.h
