### PR TITLE
chore: 完善cpu信息获取接口（cpuModelName）

### DIFF
--- a/src/dsysinfo.cpp
+++ b/src/dsysinfo.cpp
@@ -60,7 +60,7 @@ public:
     void ensureReleaseInfo();
     void ensureComputerInfo();
     QMap<QString, QString> parseInfoFile(QFile &file);
-
+    QMap<QString, QString> parseInfoContent(const QString &content);
 #ifdef Q_OS_LINUX
     DSysInfo::DeepinType deepinType = DSysInfo::DeepinType(-1);
     QMap<QString, QString> deepinTypeMap; //Type Name with Language
@@ -512,6 +512,21 @@ QMap<QString, QString> DSysInfoPrivate::parseInfoFile(QFile &file)
             }
         }
     } while (lineLength >= 0);
+    return map;
+}
+
+QMap<QString, QString> DSysInfoPrivate::parseInfoContent(const QString &content)
+{
+    QMap<QString, QString> map;
+    QStringList lineContents = content.split("\n");
+    for (auto lineContent : lineContents) {
+        if (lineContent.contains(':')) {
+            QStringList list = lineContent.split(':');
+            if (list.size() == 2) {
+                map.insert(list.first().trimmed(), list.back().trimmed());
+            }
+        }
+    }
     return map;
 }
 
@@ -984,6 +999,9 @@ QString DSysInfo::computerName()
 
 QString DSysInfo::cpuModelName()
 {
+    if (!siGlobal->cpuModelName.isEmpty())
+        return siGlobal->cpuModelName;
+
 #ifdef Q_OS_LINUX
     static QFile file("/proc/cpuinfo");
 
@@ -998,10 +1016,31 @@ QString DSysInfo::cpuModelName()
         } else if (map.contains("cpu model")) {
             // loonson3-cpuinfo sw-cpuinfo
             siGlobal->cpuModelName = map.value("cpu model");
+        } else if (map.contains("Hardware")) {
+            // "HardWare" field contains cpu info on huawei kirin machine (e.g. klv or klu)
+            siGlobal->cpuModelName = map.value("Hardware");
         }
 
         file.close();
     }
+
+    // Get the cpu info by executing lscpu command
+    if (siGlobal->cpuModelName.isEmpty()) {
+        QProcess lscpu;
+        QStringList env = QProcess::systemEnvironment();
+        env << "LC_ALL=C"; // Add an environment variable
+        lscpu.setEnvironment(env);
+        lscpu.start("/usr/bin/lscpu");
+        if (lscpu.waitForFinished(3000)) {
+            const QMap<QString, QString> map = siGlobal->parseInfoContent(lscpu.readAll());
+            if (map.contains("Model name")) {
+                siGlobal->cpuModelName = map.value("Model name");
+            }
+        } else {
+            qWarning() << "lscpu:" << lscpu.errorString();
+        }
+    }
+
     return siGlobal->cpuModelName;
 #endif
     return QString();


### PR DESCRIPTION
分别按以下顺序取其值，取到就返回：
1. 首先匹配sw，hw-klv里的特殊字段；
2. 然后取model name字段；
3. 最后通过lscpu命令获取；

Log: 修改cpu信息获取接口
Task: https://pms.uniontech.com/task-view-218217.html
Influence: cpuModelName接口
Change-Id: I6ba1a66f1d898725ebcb9a59791f6d466149a3a3