### PR TITLE
fix: missing implementation and obsolete Member

### DIFF
--- a/include/log/RollingFileAppender.h
+++ b/include/log/RollingFileAppender.h
@@ -42,7 +42,7 @@ class LIBDTKCORESHARED_EXPORT RollingFileAppender : public FileAppender
     void setLogFilesLimit(int limit);
     int logFilesLimit() const;
 
-    void setLogSizeLimit(int qint64);
+    void setLogSizeLimit(int limit);
     qint64 logSizeLimit() const;
 
   protected:

--- a/src/filesystem/dcapfile.cpp
+++ b/src/filesystem/dcapfile.cpp
@@ -81,7 +81,7 @@ QString DCapFile::readLink() const
     if (!d->canReadWrite(d->fileName))
         return {};
 
-    return QFile::readLink();
+    return QFile::symLinkTarget();
 }
 
 #if QT_VERSION >= QT_VERSION_CHECK(5, 13, 0)

--- a/src/log/RollingFileAppender.cpp
+++ b/src/log/RollingFileAppender.cpp
@@ -241,4 +241,16 @@ int RollingFileAppender::logFilesLimit() const
     return m_logFilesLimit;
 }
 
+void RollingFileAppender::setLogSizeLimit(int limit)
+{
+    QMutexLocker locker(&m_rollingMutex);
+    m_logSizeLimit = limit;
+}
+
+qint64 RollingFileAppender::logSizeLimit() const
+{
+    QMutexLocker locker(&m_rollingMutex);
+    return m_logSizeLimit;
+}
+
 DCORE_END_NAMESPACE


### PR DESCRIPTION
add missing imple of rollingfileappender
use Use QFile::symLinkTarget() instead of QFile::readLink()

Log: none
Influence: none
Change-Id: I7cf642fed010bcb73f1c3ebca0c2bfd3a6795dad