### PR TITLE
chore dci tool and install dci cli tool

### DIFF
--- a/tools/dci/CMakeLists.txt
+++ b/tools/dci/CMakeLists.txt
@@ -20,3 +20,5 @@ target_include_directories(${BIN_NAME} PUBLIC
   ../../include/global/
 )
 #end dci
+
+install(TARGETS ${BIN_NAME} DESTINATION "${TOOL_INSTALL_DIR}")


### PR DESCRIPTION
1. add --tree args to view files in dci file
2. install dci cli tool in libdtkcore5-bin
3. fix invaild link when export dci file
```
 ./dci --tree ~/Desktop/ps.dci/android-device.dci
/
└── /256
    ├── normal.dark
    │   ├── 2
    │   │   └── 1.webp -> /256/normal.light/2/1.webp
    │   └── 3
    │       └── 1.webp -> /256/normal.light/3/1.webp
    └── normal.light
        ├── 2
        │   └── 1.webp
        └── 3
            └── 1.webp
```