### PR TITLE
chore: fix linking error

### DIFF
--- a/misc/DtkConfig.cmake.in
+++ b/misc/DtkConfig.cmake.in
@@ -3,7 +3,7 @@
 set_and_check(DtkCore_INCLUDE_DIRS "@PACKAGE_INCLUDE_INSTALL_DIR@")
 set_and_check(DtkCore_LIBRARY_DIRS "@PACKAGE_LIBRARY_INSTALL_DIR@")
 set(DtkCore_TOOL_DIRS "@PACKAGE_TOOL_INSTALL_DIR@")
-set(DtkCore_LIBRARIES dtkcore)
+find_library(DtkCore_LIBRARIES dtkcore ${DtkCore_LIBRARY_DIRS})
 
 include_directories("${DtkCore_INCLUDE_DIRS}")
 


### PR DESCRIPTION
DtkCoreConfig.cmake will always find the library under system library path. This will cause a linking error when you want to use the version deployed by yourself. Fix that by appending the path prefix.

Log: fix DtkConfig.cmake.in
Influence: DtkConfig.cmake.in