### PR TITLE
chore: Update dsysinfo.cpp

### DIFF
--- a/src/dsysinfo.cpp
+++ b/src/dsysinfo.cpp
@@ -1107,10 +1107,10 @@ qint64 DSysInfo::systemDiskSize()
 {
 #ifdef Q_OS_LINUX
     // Getting Disk Size
-    const QString &deviceName = QStorageInfo::root().device();
+    QString deviceName;
     QProcess lsblk;
 
-    lsblk.start("lsblk", {"-Jlpb", "-oNAME,KNAME,PKNAME,SIZE"}, QIODevice::ReadOnly);
+    lsblk.start("lsblk", {"-Jlpb", "-oNAME,KNAME,PKNAME,SIZE,MOUNTPOINT"}, QIODevice::ReadOnly);
 
     if (!lsblk.waitForFinished()) {
         return -1;
@@ -1130,6 +1130,11 @@ qint64 DSysInfo::systemDiskSize()
             QString kname = oneValue.toObject().value("kname").toString();
             QString pkname = oneValue.toObject().value("pkname").toString();
             qulonglong size = oneValue.toObject().value("size").toVariant().toULongLong();
+            QString deviceNameMP = oneValue.toObject().value("mountpoint").toString();
+
+            if ("/" ==  deviceNameMP){
+                deviceName = name;
+            }
 
             if (keyName.isNull() && deviceName == name) {
                 keyName = kname;


### PR DESCRIPTION
QStorageInfo::root().device()扫描的是/etc/mtab里的内容，但是有的根节点就只会显示/dev/root，这个会导致在控制中心显示磁盘容量的时候不能 显示，故现更改获取根挂载点的方式，在lsblk的方法上增加。

Log: