### PR TITLE
chore: remove find_dependency

### DIFF
--- a/misc/DtkConfig.cmake.in
+++ b/misc/DtkConfig.cmake.in
@@ -1,15 +1,5 @@
 @PACKAGE_INIT@
 
-if(UNIX AND NOT APPLE)
-  set(LINUX TRUE)
-endif()
-include(CMakeFindDependencyMacro)
-find_dependency(Qt5Core)
-find_dependency(Qt5Xml)
-if (LINUX)
-    find_dependency(Qt5DBus) 
-endif()
-
 include(${CMAKE_CURRENT_LIST_DIR}/DtkCoreTargets.cmake)
 
 set(DtkCore_LIBRARIES Dtk::Core)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -65,13 +65,10 @@ if(LINUX)
     ${utils_SRC}
     ${glob_SRC}
   )
-  target_link_libraries(
-    ${LIBNAME} PUBLIC 
+  target_link_libraries(${LIBNAME} PRIVATE
     Qt5::Core 
     Qt5::DBus
     Qt5::Xml
-  )
-  target_link_libraries(${LIBNAME} PRIVATE
     ${QGSettings_LIBRARIES}
     ICU::uc
     uchardet
@@ -86,12 +83,9 @@ else()
     ${utils_SRC}
     ${glob_SRC}
   )
-  target_link_libraries(
-    ${LIBNAME} PUBLIC 
-    Qt5::Core 
-    Qt5::Xml
-  )
   target_link_libraries(${LIBNAME} PRIVATE
+    Qt5::Core
+    Qt5::Xml
     ICU::uc
     uchardet
   )


### PR DESCRIPTION
For some reason, dtkcore now won't find any dependency.

Log: remove find_dependency in DtkCoreConfig.cmake