### PR TITLE
feat: Add empty appid support for DConfig

### DIFF
--- a/docs/global/dconfig.zh_CN.dox
+++ b/docs/global/dconfig.zh_CN.dox
@@ -300,7 +300,7 @@ sudo make install
 @param[in] parent 父对象
 
 @fn static DConfig* Dtk::Core::DConfig::create(const QString &appId, const QString &name, const QString &subpath, QObject *parent)
-@brief 构造配置策略提供的对象,指定配置所属的应用Id。
+@brief 构造配置策略提供的对象,指定配置所属的应用Id，管理某一特定应用的配置。
 @param[in] appId 配置文件所属的应用Id,为空时默认为本应用Id
 @param[in] name 配置文件名
 @param[in] subpath 配置文件对应的子目录
@@ -315,6 +315,17 @@ sudo make install
 @param[in] subpath 配置文件对应的子目录
 @param[in] parent 父对象
 @return 构造的配置策略对象,由调用者释放
+
+@fn static DConfig* Dtk::Core::DConfig::createGeneric(const QString &name, const QString &subpath, QObject *parent)
+@brief 构造配置策略提供的对象，用来管理与应用无关的配置。
+@param[in] name 配置文件名
+@param[in] subpath 配置文件对应的子目录
+@param[in] parent 父对象
+@return 构造的配置策略对象,由调用者释放
+@note 如果我们管理针对某一特定应用的配置，应该使用 Dtk::Core::DConfig::create()，或 Dtk::Core::DConfig()，来指定所属应用的appId。
+
+@fn static DConfig* Dtk::Core::DConfig::createGeneric(DConfigBackend *backend, const QString &name, const QString &subpath, QObject *parent)
+@sa Dtk::Core::DConfig::createGeneric()
 
 @fn DConfig Dtk::Core::DConfig(DConfigBackend *backend, const QString &appId, const QString &name, const QString &subpath, QObject *parent)
 @brief 使用自定义的配置策略后端构造对象

--- a/docs/global/dconfigfile.zh_CN.dox
+++ b/docs/global/dconfigfile.zh_CN.dox
@@ -256,7 +256,13 @@ sudo ./dconfigfile-example
 @fn QVariant Dtk::Core::DConfigFile::value(const QString &key, DConfigCache *userCache = nullptr) const
 @brief DConfigFile::value
 @param[in] key 配置项名称
-@param[in] uid 用户id,当key为全局项时,uid无效
+@param[in] userCache 用户缓存,当key为全局项时, \a userCache 不会被使用
+@return
+
+@fn QVariant Dtk::Core::DConfigFile::cacheValue(DConfigCache *userCache, const QString &key) const
+@brief DConfigFile::cacheValue 获取指定用户缓存的配置项值，若无此配置项的用户缓存值，返回无效值
+@param[in] key 配置项名称
+@param[in] userCache 用户缓存,当key为全局配置项时, \a userCache 不会被使用
 @return
 
 @fn bool Dtk::Core::DConfigFile::setValue(const QString &key, const QVariant &value, const QString &callerAppid, DConfigCache *userCache = nullptr)

--- a/include/global/dconfig.h
+++ b/include/global/dconfig.h
@@ -43,6 +43,10 @@ public:
                            QObject *parent = nullptr);
     static DConfig *create(DConfigBackend *backend, const QString &appId, const QString &name, const QString &subpath = QString(),
                                   QObject *parent = nullptr);
+    static DConfig *createGeneric(const QString &name, const QString &subpath = QString(),
+                                  QObject *parent = nullptr);
+    static DConfig *createGeneric(DConfigBackend *backend, const QString &name, const QString &subpath = QString(),
+                                  QObject *parent = nullptr);
 
     QString backendName() const;
 

--- a/include/global/dconfigfile.h
+++ b/include/global/dconfigfile.h
@@ -61,6 +61,7 @@ public:
 
     bool isValid() const;
     QVariant value(const QString &key, DConfigCache *userCache = nullptr) const;
+    QVariant cacheValue(DConfigCache *userCache, const QString &key) const;
     bool setValue(const QString &key, const QVariant &value, const QString &callerAppid,
                   DConfigCache *userCache = nullptr);
 

--- a/tests/ut_dconfig.cpp
+++ b/tests/ut_dconfig.cpp
@@ -20,7 +20,6 @@ class ut_DConfig : public testing::Test
 protected:
     static void SetUpTestCase() {
         fileBackendLocalPerfix.set("DSG_DCONFIG_FILE_BACKEND_LOCAL_PREFIX", "/tmp/example");
-        metaGuard = new FileCopyGuard(":/data/dconf-example.meta.json", QString("%1" PREFIX"/share/dsg/configs/%2/%3.json").arg(fileBackendLocalPerfix.value(), APP_ID, FILE_NAME));
 
         backendType.set("DSG_DCONFIG_BACKEND_TYPE", "FileBackend");
         dsgDataDir.set("DSG_DATA_DIRS", PREFIX"/share/dsg");
@@ -28,34 +27,43 @@ protected:
     static void TearDownTestCase() {
         QDir(fileBackendLocalPerfix.value()).removeRecursively();
         fileBackendLocalPerfix.restore();
-        delete metaGuard;
 
         backendType.restore();
         dsgDataDir.restore();
     }
     virtual void SetUp() override;
+    virtual void TearDown() override;
 
     static EnvGuard backendType;
     static EnvGuard fileBackendLocalPerfix;
-    static FileCopyGuard *metaGuard;
+    QString metaFilePath = QString("%1" PREFIX"/share/dsg/configs/%2/%3.json").arg(fileBackendLocalPerfix.value(), APP_ID, FILE_NAME);
+    QString noAppIdMetaFilePath = QString("%1" PREFIX"/share/dsg/configs/%2.json").arg(fileBackendLocalPerfix.value(), FILE_NAME);
 };
 EnvGuard ut_DConfig::fileBackendLocalPerfix;
 EnvGuard ut_DConfig::backendType;
-FileCopyGuard *ut_DConfig::metaGuard = nullptr;
+
+void ut_DConfig::TearDown()
+{
+    QDir(fileBackendLocalPerfix.value()).removeRecursively();
+}
 
 TEST_F(ut_DConfig, backend) {
 
+    FileCopyGuard guard(":/data/dconf-example.meta.json", metaFilePath);
     DConfig config(FILE_NAME);
     ASSERT_EQ(config.backendName(), QString("FileBackend"));
 }
 
 TEST_F(ut_DConfig, isValid) {
 
+    FileCopyGuard guard(":/data/dconf-example.meta.json", metaFilePath);
     DConfig config(FILE_NAME);
     ASSERT_TRUE(config.isValid());
 }
 
 TEST_F(ut_DConfig, value) {
+
+    FileCopyGuard guard(":/data/dconf-example.meta.json", metaFilePath);
     const QStringList array{"1", "2"};
     QVariantMap map;
     map.insert("key1", "value1");
@@ -102,6 +110,7 @@ TEST_F(ut_DConfig, value) {
 
 TEST_F(ut_DConfig, keyList) {
 
+    FileCopyGuard guard(":/data/dconf-example.meta.json", metaFilePath);
     DConfig config(FILE_NAME);
     QStringList keyList{QString("key2"), QString("canExit")};
     for (auto item : keyList) {
@@ -111,12 +120,60 @@ TEST_F(ut_DConfig, keyList) {
 
 TEST_F(ut_DConfig, OtherAppConfigfile) {
 
+    FileCopyGuard guard(":/data/dconf-example.meta.json", metaFilePath);
+
     constexpr char const *APP_OTHER = "tests_other";
     FileCopyGuard gurand(":/data/dconf-example_other_app_configure.meta.json", QString("%1" PREFIX"/share/dsg/configs/%2/%3.json").arg(fileBackendLocalPerfix.value(), APP_OTHER, FILE_NAME));
 
     QScopedPointer<DConfig> config(DConfig::create(APP_OTHER, FILE_NAME));
     ASSERT_TRUE(config->isValid());
     ASSERT_EQ(config->value("appPublic").toString(), QString("publicValue"));
+}
+
+TEST_F(ut_DConfig, appIdWriteConfig) {
+
+    FileCopyGuard guard(":/data/dconf-example.meta.json", noAppIdMetaFilePath);
+    {
+        // 内部会传递appid，强制appid不为空
+        DConfig config(FILE_NAME);
+        config.setValue("key2", "user-with-appid");
+        ASSERT_EQ(config.value("key2"), "user-with-appid");
+    }
+    {
+        // appid为公共id
+        QScopedPointer<DConfig> config(DConfig::createGeneric(FILE_NAME));
+        ASSERT_TRUE(config->isValid());
+        ASSERT_EQ(config->value("key2").toString(), QString("125"));
+    }
+    {
+        // 传递appid
+        QScopedPointer<DConfig> config(DConfig::create(APP_ID, FILE_NAME));
+        ASSERT_TRUE(config->isValid());
+        ASSERT_EQ(config->value("key2").toString(), "user-with-appid");
+    }
+}
+
+TEST_F(ut_DConfig, noAppidWirteConfig) {
+
+    FileCopyGuard guard(":/data/dconf-example.meta.json", noAppIdMetaFilePath);
+    FileCopyGuard guard2(":/data/dconf-example.meta.json", metaFilePath);
+    {
+        // 内部会传递appid，强制appid不为公共id
+        QScopedPointer<DConfig> config(DConfig::createGeneric(FILE_NAME));
+        ASSERT_TRUE(config->isValid());
+        config->setValue("key2", "user-with-no-appid");
+        ASSERT_EQ(config->value("key2"), "user-with-no-appid");
+    }
+    {
+        // appid为公共id，获取公共id的值
+        QScopedPointer<DConfig> config(DConfig::createGeneric(FILE_NAME));
+        ASSERT_EQ(config->value("key2"), "user-with-no-appid");
+    }
+    {
+        // 传递appid，fallback到公共id的值
+        QScopedPointer<DConfig> config(DConfig::create(APP_ID, FILE_NAME));
+        ASSERT_EQ(config->value("key2"), "user-with-no-appid");
+    }
 }
 
 void ut_DConfig::SetUp() {}


### PR DESCRIPTION
  All application use same configuration by empty appid.
  Loading cache file can fallback to noappid's directory when not
using appid or not find cache file.
  one application writes configuration.
  ```c++
  auto config = DConfig::createGeneric(FileName);
  config->setValue("common-configuration", true);
  ```
  other applications read configration can give appid or not to
get the configuration.

  Set empty string for DBus caller when using `acquireManager`.

Log: 配置策略支持空appid，缓存精准匹配到meta是否使用appid
Influence: none

Change-Id: I78b331f9c455617d5dfea6df087b1f4828390974