### PR TITLE
fix: Losing dconfig info when compiling and packaging

### DIFF
--- a/archlinux/PKGBUILD
+++ b/archlinux/PKGBUILD
@@ -23,7 +23,8 @@ build() {
       -DQCH_INSTALL_DESTINATION=share/doc/qt \
       -DCMAKE_INSTALL_LIBDIR=lib \
       -DCMAKE_INSTALL_PREFIX=/usr \
-      -DCMAKE_BUILD_TYPE=Release
+      -DCMAKE_BUILD_TYPE=Release \
+      -DD_DSG_APP_DATA_FALLBACK=/var/dsg/appdata
   ninja
 }
 

--- a/debian/rules
+++ b/debian/rules
@@ -16,7 +16,7 @@ BUILD_VER = $(shell echo $(VERSION) | awk -F'[+_~-]' '{print $$2}' | sed 's/[^0-
 	dh $@
 
 override_dh_auto_configure:
-	dh_auto_configure -- -DBUILD_EXAMPLES=OFF -DBUILD_DOCS=ON -DBUILD_VERSION=$(BUILD_VER) -DDVERSION=$(PACK_VER)
+	dh_auto_configure -- -DBUILD_EXAMPLES=OFF -DBUILD_DOCS=ON -DBUILD_VERSION=$(BUILD_VER) -DDVERSION=$(PACK_VER) -DD_DSG_APP_DATA_FALLBACK=/var/dsg/appdata
 
 #override_dh_auto_test:
 #	echo "skip auto test"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -28,11 +28,6 @@ pkg_check_modules(uchardet REQUIRED uchardet)
 # start base
 include(base/base.cmake)
 # end base
-if(LINUX)
-  include(dbus/dbus.cmake)
-endif()
-#message(${dbus_SRCS})
-# end dbus
 
 # start dci
 include(dci/dci.cmake)
@@ -57,7 +52,6 @@ include(glob.cmake)
 #endGLOG
 if(LINUX)
   add_library(${LIBNAME} SHARED
-    ${dbus_SRCS}
     ${base_SRCS}
     ${dci_SRCS}
     ${filesystem_SRCS}

--- a/src/glob.cmake
+++ b/src/glob.cmake
@@ -1,29 +1,42 @@
+set(OUTER_SOURCE
+  ${CMAKE_CURRENT_LIST_DIR}/dconfig.cpp
+  ${CMAKE_CURRENT_LIST_DIR}/dsgapplication.cpp
+  ${CMAKE_CURRENT_LIST_DIR}/dsysinfo.cpp
+  ${CMAKE_CURRENT_LIST_DIR}/dsecurestring.cpp
+  ${CMAKE_CURRENT_LIST_DIR}/ddesktopentry.cpp
+  ${CMAKE_CURRENT_LIST_DIR}/dtkcore_global.cpp
+)
+set(OUTER_HEADER
+  ${CMAKE_CURRENT_LIST_DIR}/../include/global/dtkcore_global.h
+  ${CMAKE_CURRENT_LIST_DIR}/../include/global/dconfig.h
+  ${CMAKE_CURRENT_LIST_DIR}/../include/global/dsgapplication.h
+  ${CMAKE_CURRENT_LIST_DIR}/../include/global/dsysinfo.h
+  ${CMAKE_CURRENT_LIST_DIR}/../include/global/dsecurestring.h
+  ${CMAKE_CURRENT_LIST_DIR}/../include/global/ddesktopentry.h
+)
+
 if(LINUX)
-  file(GLOB OUTER_SOURCE
-    ${CMAKE_CURRENT_LIST_DIR}/*.cpp
+  if(DEFINED D_DSG_APP_DATA_FALLBACK)
+      add_definitions(-DD_DSG_APP_DATA_FALLBACK="${D_DSG_APP_DATA_FALLBACK}")
+  endif()
+  list(APPEND OUTER_SOURCE
+    ${CMAKE_CURRENT_LIST_DIR}/dconfigfile.cpp
   )
-  file(GLOB OUTER_HEADER
-    ${CMAKE_CURRENT_LIST_DIR}/../include/global/*.h 
+  list(APPEND OUTER_HEADER
+    ${CMAKE_CURRENT_LIST_DIR}/../include/global/dconfigfile.h
   )
+#   generic dbus interfaces
+  if(NOT DEFINED DTK_DISABLE_DBUS_CONFIG)
+    include(${CMAKE_CURRENT_LIST_DIR}/dbus/dbus.cmake)
+    list(APPEND glob_SRC ${dbus_SRCS})
+  else()
+    add_definitions(-DD_DISABLE_DBUS_CONFIG)
+  endif()
 else()
-  set(OUTER_SOURCE 
-    ${CMAKE_CURRENT_LIST_DIR}/dconfig.cpp 
-    ${CMAKE_CURRENT_LIST_DIR}/dsgapplication.cpp 
-    ${CMAKE_CURRENT_LIST_DIR}/dsysinfo.cpp 
-    ${CMAKE_CURRENT_LIST_DIR}/dsecurestring.cpp 
-    ${CMAKE_CURRENT_LIST_DIR}/ddesktopentry.cpp 
-    ${CMAKE_CURRENT_LIST_DIR}/dtkcore_global.cpp
-  )
-  set(OUTER_HEADER 
-    ${CMAKE_CURRENT_LIST_DIR}/../include/global/dtkcore_global.h 
-    ${CMAKE_CURRENT_LIST_DIR}/../include/dconfig.h 
-    ${CMAKE_CURRENT_LIST_DIR}/../include/dsgapplication.h 
-    ${CMAKE_CURRENT_LIST_DIR}/../include/dsysinfo.h 
-    ${CMAKE_CURRENT_LIST_DIR}/../include/dsecurestring.h 
-    ${CMAKE_CURRENT_LIST_DIR}/../include/ddesktopentry.h
-  )
+    add_definitions(-DD_DISABLE_DCONFIG)
 endif()
-set(glob_SRC
+
+list(APPEND glob_SRC
   ${OUTER_HEADER}
   ${OUTER_SOURCE}
 )

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -28,11 +28,6 @@ find_package(GTest REQUIRED)
 include(../src/base/base.cmake)
 
 # end base
-if(LINUX)
-  include(../src/dbus/dbus.cmake)
-endif()
-#message(${dbus_SRCS})
-# end dbus
 
 # start dci
 include(../src/dci/dci.cmake)
@@ -78,7 +73,6 @@ set(test_SRC
 # end test
 if(LINUX)
   add_executable(${BIN_NAME}
-    ${dbus_SRCS}
     ${base_SRCS}
     ${dci_SRCS}
     ${filesystem_SRCS}


### PR DESCRIPTION
  Add adjust for linux when compile.
  Add `D_DSG_APP_DATA_FALLBACK` macro when packaging.
 see the commit: 7b13e5c4b867fcbdcc50f5e409b0c8726496b7e5

Log: none
Influence: none
Change-Id: Ie047dbd2d8158ed5242dfb5bcc7fa4e02ee1d925