### PR TITLE
fix: missing BUILD_WITH_SYSTEMD macro

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -77,6 +77,7 @@ if(LINUX)
     target_link_libraries(${LIBNAME} PRIVATE
       PkgConfig::Systemd
     )
+    add_definitions(-DBUILD_WITH_SYSTEMD)
   endif()
 
 else()


### PR DESCRIPTION
  Define macro to be used in cpp.

Log: none
Influence: none
Change-Id: I40f743e74b5a5c5eb8e94e4ba099747d3d88523d