### PR TITLE
fix: Lossing quotation mark for DSG_DATA_DIR macro

### DIFF
--- a/cmake/DtkDConfig/DtkDConfigConfig.cmake
+++ b/cmake/DtkDConfig/DtkDConfigConfig.cmake
@@ -21,7 +21,7 @@ if(NOT DEFINED DSG_DATA_DIR)
     set(DSG_DATA_DIR ${CMAKE_INSTALL_PREFIX}/share/dsg)
 endif()
 
-add_definitions(-DDSG_DATA_DIR=${DSG_DATA_DIR})
+add_definitions(-DDSG_DATA_DIR=\"${DSG_DATA_DIR}\")
 # deploy some `meta` 's configure.
 #
 # FILES       - deployed files.


### PR DESCRIPTION
  Add quotation mark for macro.

Log: none
Influence: none
Change-Id: Iaf26210a81e7c2e167e30b976c5e0a1ec26708b9