### PR TITLE
chore: specify dtkcommon version

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -28,7 +28,7 @@ Description: Deepin Tool Kit Core Utilities
 
 Package: libdtkcore-dev
 Architecture: any
-Depends: ${shlibs:Depends}, ${misc:Depends}, libdtkcore5( =${binary:Version}), libdtkcommon-dev
+Depends: ${shlibs:Depends}, ${misc:Depends}, libdtkcore5( =${binary:Version}), libdtkcommon-dev(>=5.6.4)
 Description: Deepin Tool Kit Core Devel library
  DtkCore is base devel library of Deepin Qt/C++ applications.
  .


### PR DESCRIPTION
dconfig prf and cmake modules were move to dtkcore dtkcommon depends >= 5.6.4

Log: fix install conflict