### PR TITLE
fix: qch generate error

### DIFF
--- a/docs/filesystem/index.zh_CN.md
+++ b/docs/filesystem/index.zh_CN.md
@@ -1,7 +1,7 @@
 @page dfilesystem dfilesystem--dtk文件系统操作的封装
 
 
-## Dlog：dtk日志组件
+# Dlog：dtk日志组件
 
 TODO：添加filesystem组件使用说明
 @defgroup dfilesystem

--- a/docs/global/index.zh_CN.md
+++ b/docs/global/index.zh_CN.md
@@ -1,7 +1,7 @@
 @page global global--dtk全局工具组件
 
-## DTk global：dtk全局工具类
-### dsysinfo：dtk系统信息工具类
+# DTk global：dtk全局工具类
+## dsysinfo：dtk系统信息工具类
 
 [dsysinfo.h 详细文档](dsysinfo_8h.html)<br>
 这里放一个最小化使用dsysinfo的例子:<br>

--- a/docs/util/index.zh_CN.md
+++ b/docs/util/index.zh_CN.md
@@ -1,8 +1,6 @@
-# DTK util
+@page util util--DTK工具组件
 
-@mainpage
-@defgroup dutil
-@brief dtk实用工具
+# DTK util
 
 ## 模块介绍
 
@@ -10,3 +8,6 @@
 
 + 同种数据类的单位转换接口
 + DBus接口工具类
+
+@defgroup dutil
+@brief dtk实用工具


### PR DESCRIPTION
qhelpgenerator run failure due to wrong markdown title tree. Change index title level to fix.

Log: fix qch generate error