### PR TITLE
fix: Get back dtkcore_config.h

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,7 +21,6 @@ build*/
 *.qm
 
 src/DtkCores
-src/dtkcore_config.h
 cmake/DtkCore/DtkCoreConfig.cmake
 src/qt_lib_d*.pri
 
@@ -34,7 +33,6 @@ cmake/DtkCore*
 DtkCoreConfig.cmake
 dtkcore.pc
 qt_lib_dtkcore.pri
-dtkcore_config.h
 CMakeLists.txt.user
 
 #tools


### PR DESCRIPTION
This header file is included by dtkcore_global.h, but it's mysteriously missing. You can't even see it on GitHub! I got it back by coincidence.
 
Log: none