### PR TITLE
feat: Support cache to be relocated for DConfigFile

### DIFF
--- a/docs/global/dconfigfile.zh_CN.dox
+++ b/docs/global/dconfigfile.zh_CN.dox
@@ -419,4 +419,8 @@ sudo ./dconfigfile-example
 @brief 用户标识,为全局缓存时,uid为非用户标识的特定值
 @return
 
+@fn virtual void setCachePathPrefix(const QString &prefix) = 0
+@brief 指定缓存位置前缀，缓存访问所需的权限及区分不同缓存的位置由调用者考虑，其默认值参考配置策略规范
+@param[in] prefix 缓存位置的前缀
+
 */

--- a/include/global/dconfigfile.h
+++ b/include/global/dconfigfile.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2021 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2021 - 2023 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
@@ -115,6 +115,8 @@ public:
     virtual QVariant value(const QString &key) const = 0;
     virtual int serial(const QString &key) const = 0;
     virtual uint uid() const = 0;
+
+    virtual void setCachePathPrefix(const QString &prefix) = 0;
 };
 
 #ifndef QT_NO_DEBUG_STREAM


### PR DESCRIPTION
  Add setCachePrefix function to support that cache can be relocated
by caller, It's default value doesn't changed, and we can refer to
`配置文件规范` in https://github.com/linuxdeepin/deepin-specifications.
  Permissions is left to the caller.
  For DConfig's FileBackend, we use it's default value.

Issue: https://github.com/linuxdeepin/dtkcore/issues/271