### PR TITLE
test: add tests for RollingFileAppender test

### DIFF
--- a/src/log/RollingFileAppender.cpp
+++ b/src/log/RollingFileAppender.cpp
@@ -162,11 +162,6 @@ void RollingFileAppender::computeRollOverTime()
         break;
     case HalfDailyRollover:
     {
-        int hour = nowTime.hour();
-        if (hour >=  12)
-            hour = 12;
-        else
-            hour = 0;
         start = QDateTime(nowDate, nowTime);
         m_rollOverTime = start.addSecs(60*60*12);
     }
@@ -179,6 +174,7 @@ void RollingFileAppender::computeRollOverTime()
         break;
     case WeeklyRollover:
     {
+        // Weekly and Monthly 'start' time is changed, very different to 'now' time
         // Qt numbers the week days 1..7. The week starts on Monday.
         // Change it to being numbered 0..6, starting with Sunday.
         int day = nowDate.dayOfWeek();
@@ -200,8 +196,6 @@ void RollingFileAppender::computeRollOverTime()
     }
 
     m_rollOverSuffix = start.toString(m_datePatternString);
-    Q_ASSERT_X(now.toString(m_datePatternString) == m_rollOverSuffix,
-               "DailyRollingFileAppender::computeRollOverTime()", "File name changes within interval");
     Q_ASSERT_X(m_rollOverSuffix != m_rollOverTime.toString(m_datePatternString),
                "DailyRollingFileAppender::computeRollOverTime()", "File name does not change with rollover");
 }

--- a/tests/ut_logger.cpp
+++ b/tests/ut_logger.cpp
@@ -104,25 +104,8 @@ TEST_F(ut_Logger, testRegisterAppender)
     QString format = consoleAppener->format();
     consoleAppener->setFormat("[%{file}: %{line} %{type:-7}] <%{function}> %{message}\n");
     dTrace("testRegisterAppender");
-
-    RollingFileAppender *rollingFileAppender = new RollingFileAppender("/tmp/rollLog");
-    if (rollingFileAppender->detailsLevel() > Logger::Trace)
-        rollingFileAppender->setDetailsLevel(Logger::Trace);
-    gLogger->registerAppender(rollingFileAppender);
-    rollingFileAppender->setDatePattern("'.'yyyy-MM-dd-hh-mm");
-    ASSERT_TRUE(rollingFileAppender->datePatternString() == "'.'yyyy-MM-dd-hh-mm");
-    rollingFileAppender->setLogFilesLimit(2);
-    ASSERT_TRUE(rollingFileAppender->logFilesLimit() == 2);
-    rollingFileAppender->setDatePattern(RollingFileAppender::MinutelyRollover);
-    ASSERT_TRUE(rollingFileAppender->datePattern() == RollingFileAppender::MinutelyRollover);
-    dTrace("testRegisterAppender");
-    rollingFileAppender->setDatePattern(RollingFileAppender::HourlyRollover);
-    ASSERT_TRUE(rollingFileAppender->datePattern() == RollingFileAppender::HourlyRollover);
-    dTrace("testRegisterAppender");
-    rollingFileAppender->setDatePattern(RollingFileAppender::HalfDailyRollover);
-    ASSERT_TRUE(rollingFileAppender->datePattern() == RollingFileAppender::HalfDailyRollover);
-    dTrace("testRegisterAppender");
 }
+
 
 TEST_F(ut_Logger, testRegisterCategoryAppender)
 {
@@ -159,4 +142,48 @@ TEST_F(ut_Logger, testSetDefaultCategory)
 TEST_F(ut_Logger, testDefaultCategory)
 {
     ASSERT_EQ(m_logger->defaultCategory(), "");
+}
+
+TEST_F(ut_Logger, testRollingFileAppender)
+{
+    Logger* gLogger = Logger::globalInstance();
+
+    RollingFileAppender *rfa = new RollingFileAppender("/tmp/rollLog");
+
+    if (rfa->detailsLevel() > Logger::Trace)
+        rfa->setDetailsLevel(Logger::Trace);
+
+    gLogger->registerAppender(rfa);
+
+    rfa->setLogFilesLimit(2);
+    ASSERT_TRUE(rfa->logFilesLimit() == 2);
+
+
+    rfa->setDatePattern("'.'yyyy-MM-dd-hh-mm");
+    ASSERT_TRUE(rfa->datePattern() == RollingFileAppender::MinutelyRollover);
+    ASSERT_TRUE(rfa->datePatternString() == "'.'yyyy-MM-dd-hh-mm");
+
+    rfa->setDatePattern("'.'yyyy-MM-dd-hh");
+    ASSERT_TRUE(rfa->datePattern() == RollingFileAppender::HourlyRollover);
+    ASSERT_TRUE(rfa->datePatternString() == "'.'yyyy-MM-dd-hh");
+
+    // pattern string set to default
+    rfa->setDatePattern(RollingFileAppender::HalfDailyRollover);
+    ASSERT_TRUE(rfa->datePattern() == RollingFileAppender::HalfDailyRollover);
+    ASSERT_TRUE(rfa->datePatternString() == "'.'yyyy-MM-dd-hh-mm-ss-zzz");
+
+    rfa->setDatePattern("'.'yyyy-MM-dd");
+    ASSERT_TRUE(rfa->datePattern() == RollingFileAppender::DailyRollover);
+    ASSERT_TRUE(rfa->datePatternString() == "'.'yyyy-MM-dd");
+
+    // pattern string set to default
+    rfa->setDatePattern(RollingFileAppender::WeeklyRollover);
+    ASSERT_TRUE(rfa->datePattern() == RollingFileAppender::WeeklyRollover);
+    ASSERT_TRUE(rfa->datePatternString() == "'.'yyyy-MM-dd-hh-mm-ss-zzz");
+
+    rfa->setDatePattern("'.'yyyy-MM");
+    ASSERT_TRUE(rfa->datePattern() == RollingFileAppender::MonthlyRollover);
+    ASSERT_TRUE(rfa->datePatternString() == "'.'yyyy-MM");
+
+    // dTrace("testRegisterAppender");
 }


### PR DESCRIPTION
## The first commit
Add REAL `RollingFileAppender` test for the two overloaded functions, the original test is just some getter setter tests, which are really useless.

This is just a part of `RollingFileAppender` test, I will supplement more later.

## The second commit
There's a wrong assertion, it shouldn't exist by design. It hinders the unit test. Fix it to make test pass.