### PR TITLE
fix: Temporarily fix the dead loop generated by QDebug destructor when compiling with the relocatable feature of qt

### DIFF
--- a/src/filesystem/dcapmanager.cpp
+++ b/src/filesystem/dcapmanager.cpp
@@ -104,6 +104,9 @@ DCapManager *DCapManager::instance()
 
 void DCapManager::registerFileEngine()
 {
+    // FIXME: When qt is compiled with Relocatable feature, a dead loop occurs due to the unreasonable implementation of
+    // dcapfsfileengine, temporarily suppressing the error with the following solution
+    qDebug() << "register cap fileEngine";  // initialize some global static variables
     if (globalHandler)
         return;
     globalHandler = new DCapFSFileEngineHandler;


### PR DESCRIPTION

Log: 暂时修复由于qt使用relocatable特性编译时QDebug析构时产生的死循环