### PR TITLE
fix: Fix incomplete copy of Vtable

### DIFF
--- a/tests/testso/testso.cpp
+++ b/tests/testso/testso.cpp
@@ -4,9 +4,9 @@
 
 #include "testso.h"
 
-bool TestClass::A::test(int v)
+char TestClass::A::test(int v)
 {
     qDebug() << Q_FUNC_INFO << this << v;
 
-    return false;
+    return 'a';
 }

--- a/tests/testso/testso.h
+++ b/tests/testso/testso.h
@@ -4,25 +4,34 @@
 
 #include <QDebug>
 
-namespace TestClass {
-class A
+namespace TestClass {  // test case use multiple inheritance
+struct A
 {
-public:
-    virtual bool test(int v);
-
+    int aa;
+    virtual char test(int v);
     virtual ~A() {}
 };
 
-class B
+struct B
 {
-public:
-    virtual bool test(int v)
+    int bx;
+    virtual char test(int v)
     {
         qDebug() << Q_FUNC_INFO << v;
 
-        return true;
+        return 'b';
     }
 
     virtual ~B() {}
+};
+
+struct C : public A, public B
+{
+    int cx;
+    char test(int v) override
+    {
+        qDebug() << Q_FUNC_INFO << v;
+        return 'c';
+    }
 };
 }  // namespace TestClass


### PR DESCRIPTION
1. 修复了因不完整拷贝引起的rtti信息丢失的问题
2. 对于虚表结尾判断增加了新的限制条件
3. 增加了调整虚表指针的方法, 后续可以考虑取消对于函数指针和对象指针类型一致的限制

Log: 修复不完整的虚表拷贝