### PR TITLE
fix!: remove DCapFSFileEngine

### DIFF
--- a/include/filesystem/dcapmanager.h
+++ b/include/filesystem/dcapmanager.h
@@ -18,7 +18,9 @@ class DCapManager : public QObject, public DObject
     D_DECLARE_PRIVATE(DCapManager)
 public:
     static DCapManager *instance();
+    QT_DEPRECATED_X("This api will no longer take effect, please use DCapDir or DCapFile")
     static void registerFileEngine();
+    QT_DEPRECATED_X("This api will no longer take effect, please use DCapDir or DCapFile")
     static void unregisterFileEngine();
 
     void appendPath(const QString &path);

--- a/src/filesystem/dcapmanager.cpp
+++ b/src/filesystem/dcapmanager.cpp
@@ -104,20 +104,10 @@ DCapManager *DCapManager::instance()
 
 void DCapManager::registerFileEngine()
 {
-    // FIXME: When qt is compiled with Relocatable feature, a dead loop occurs due to the unreasonable implementation of
-    // dcapfsfileengine, temporarily suppressing the error with the following solution
-    qDebug() << "register cap fileEngine";  // initialize some global static variables
-    if (globalHandler)
-        return;
-    globalHandler = new DCapFSFileEngineHandler;
 }
 
 void DCapManager::unregisterFileEngine()
 {
-    if (!globalHandler)
-        return;
-    delete globalHandler;
-    globalHandler = nullptr;
 }
 
 void DCapManager::appendPath(const QString &path)

--- a/tests/ut_dcapfile.cpp
+++ b/tests/ut_dcapfile.cpp
@@ -2,7 +2,6 @@
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
-#include "dcapfsfileengine_p.h"
 #include "filesystem/dcapmanager.h"
 #include "filesystem/dcapfile.h"
 
@@ -36,7 +35,6 @@ void ut_DCapFSFileEngine::SetUp()
      manager = DCapManager::instance();
      manager->removePath("/tmp");
      manager->appendPath(TMPCAP_PATH);
-     manager->registerFileEngine();
 
      file = new QFile(nullptr);
      QDir dir(TMPCAP_PATH);
@@ -46,7 +44,6 @@ void ut_DCapFSFileEngine::SetUp()
 
 void ut_DCapFSFileEngine::TearDown()
 {
-    manager->unregisterFileEngine();
     manager->appendPath("/tmp");
     delete file;
     QDir dir(TMPCAP_PATH);
@@ -54,7 +51,7 @@ void ut_DCapFSFileEngine::TearDown()
         ASSERT_TRUE(dir.removeRecursively());
 }
 
-TEST_F(ut_DCapFSFileEngine, testSubDirCanReadWrite)
+/*TEST_F(ut_DCapFSFileEngine, testSubDirCanReadWrite)
 {
     manager->appendPath("/usr/share/");
     ASSERT_FALSE(DCapFSFileEngine("").canReadWrite("/tmp/usr/share/file0"));
@@ -220,7 +217,7 @@ TEST_F(ut_DCapFSFileEngine, testDCapDirEntry)
     ASSERT_TRUE(dir.entryList(QDir::Files).length() == 10);
     manager->removePath(TMPCAP_PATH);
     ASSERT_TRUE(dir.entryList(QDir::Files).length() == 0);
-}
+}*/
 
 TEST(ut_DCapFileAndDir, testDCapFileOpen)
 {


### PR DESCRIPTION
由于在开启Relocatable的Qt上,
注册DCapFileEngine会影响到Qt内部代码产生错误的结果,
并且并没有很好的办法判断某个文件是否应该由DCapFileEngine作为后端,
所以移除

Log: 移除DCapFSFileEngine