### PR TITLE
chore: back cache of caculate memoryInstalled

### DIFF
--- a/src/dsysinfo.cpp
+++ b/src/dsysinfo.cpp
@@ -1085,6 +1085,9 @@ qint64 DSysInfo::memoryInstalledSize()
 #ifdef Q_OS_LINUX
     // Getting Memory Installed Size
     // TODO: way to not dept on lshw?
+    if (siGlobal->memoryInstalledSize >= 0) {
+        return siGlobal->memoryInstalledSize;
+    }
     if (!QStandardPaths::findExecutable("lshw").isEmpty()) {
         QProcess lshw;
 


### PR DESCRIPTION
Log: bring back cache for caculate memoryInstalled

https://github.com/linuxdeepin/dtkcore/commit/63d6f5c4b39cae172e7fff1a3a92dc4da4f739a0

原来这个计算是有缓存的，看起来是什么时候丢了