### PR TITLE
chore: Revert deleted function for DVtableHook

### DIFF
--- a/include/util/dvtablehook.h
+++ b/include/util/dvtablehook.h
@@ -327,6 +327,8 @@ public:
 private:
     static bool copyVtable(quintptr **obj);
     static bool clearGhostVtable(const void *obj);
+    Q_DECL_DEPRECATED static bool isFinalClass(quintptr *obj);
+    Q_DECL_DEPRECATED static quintptr **adjustThis(quintptr *obj);
 
     template <typename T>
     static T adjustToTop(T obj)  // vtableTop: vtable start address, Usually refers to offset_to_top

--- a/src/util/dvtablehook.cpp
+++ b/src/util/dvtablehook.cpp
@@ -296,6 +296,18 @@ quintptr DVtableHook::originalFun(const void *obj, quintptr functionOffset)
     return *(vfptr_t2 + functionOffset / sizeof(quintptr));
 }
 
+bool DVtableHook::isFinalClass(quintptr *obj)
+{
+    Q_UNUSED(obj);
+    return true;
+}
+
+quintptr **DVtableHook::adjustThis(quintptr *obj)
+{
+    Q_UNUSED(obj);
+    return nullptr;
+}
+
 #if defined(Q_OS_LINUX)
 static int readProtFromPsm(quintptr adr, size_t length)
 {


### PR DESCRIPTION
  The functions are used in template, and they aren't inline,
so we can't delete them in this version, but we can remove their implementation.
  It caused in fb4845350a4a957257118a1475d4078f75578c01