### PR TITLE
feat: DConfig add check for no existed item when override

### DIFF
--- a/src/dconfigfile.cpp
+++ b/src/dconfigfile.cpp
@@ -371,6 +371,11 @@ public:
         return values.keys();
     }
 
+    inline bool contains(const QString &key) const
+    {
+        return values.contains(key);
+    }
+
     inline void remove(const QString &key)
     {
         values.remove(key);
@@ -745,6 +750,10 @@ public:
                 auto i = contents.constBegin();
 
                 for (; i != contents.constEnd(); ++i) {
+                    if (!values.contains(i.key())) {
+                        qCWarning(cfLog, "The meta doesn't contain the override key: \"%s\".", qPrintable(i.key()));
+                        continue;
+                    }
                     // 检查是否允许 override
                     if (values.flags(i.key()) & DConfigFile::NoOverride)
                         continue;

--- a/tests/data.qrc
+++ b/tests/data.qrc
@@ -10,5 +10,6 @@
         <file>data/dconf-example_other_app_configure.meta.json</file>
         <file>data/LGPLv3.txt</file>
         <file>data/example-license.json</file>
+        <file>data/dconf-example.override.noexistitem.json</file>
     </qresource>
 </RCC>

--- a/tests/data/dconf-example.override.noexistitem.json
+++ b/tests/data/dconf-example.override.noexistitem.json
@@ -1,0 +1,11 @@
+{
+  "magic": "dsg.config.override",
+  "version": "1.0",
+  "contents": {
+    "noexistitem": {
+      "value": "override",
+      "serial": 0,
+      "permissions": "readwrite"
+    }
+  }
+}

--- a/tests/ut_dconfigfile.cpp
+++ b/tests/ut_dconfigfile.cpp
@@ -310,6 +310,17 @@ TEST_F(ut_DConfigFile, fileOverride) {
     }
 }
 
+TEST_F(ut_DConfigFile, fileOverrideNoExistItem) {
+
+    FileCopyGuard guard(":/data/dconf-example.meta.json", QString("%1/%2.json").arg(metaPath, FILE_NAME));
+    FileCopyGuard guard2(":/data/dconf-example.override.noexistitem.json", QString("%1/%2.json").arg(overridePath, FILE_NAME));
+    {
+        DConfigFile config(APP_ID, FILE_NAME);
+        ASSERT_TRUE(config.load(LocalPrefix));
+        ASSERT_FALSE(config.meta()->keyList().contains("noexistitem"));
+    }
+}
+
 TEST_F(ut_DConfigFile, noAppIdWithGlobalConfiguration) {
 
     FileCopyGuard guard(":/data/dconf-example.meta.json", QString("%1/%2.json").arg(noAppidMetaPath, FILE_NAME));


### PR DESCRIPTION
  We shouldn't add the item when override file has no existed
item in meta items.