### PR TITLE
fix(cmake): wrong use of option and wrong macro

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,10 +27,7 @@ set (FEATURES_INSTALL_DIR "${CMAKE_INSTALL_LIBDIR}/qt${QT_VERSION_MAJOR}/mkspecs
 set (CONFIG_CMAKE_INSTALL_DIR "${CMAKE_INSTALL_LIBDIR}/cmake/DtkCore" CACHE STRING "Install dir for cmake config files")
 
 set (BUILD_EXAMPLES ON CACHE BOOL "Build examples")
-option(BUILD_VERSION "buildversion" "0")
-if(NOT BUILD_VERSION)
-  set(BUILD_VERSION "0")
-endif()
+set (BUILD_VERSION "0" CACHE STRING "buildversion")
 
 if(UNIX AND NOT APPLE)
   set(LINUX TRUE)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -10,7 +10,7 @@ set(CMAKE_AUTORCC ON)
 set(CMAKE_CXX_FLAGS "-fno-access-control")
 add_compile_options(-fsanitize=address)
 add_link_options(-fsanitize=address)
-add_definitions(-DPREFIX="${CMAKE_PREFIX_PATH}")
+add_definitions(-DPREFIX="${CMAKE_INSTALL_PREFIX}")
 add_definitions(-DOS_VERSION_TEST_FILE="/tmp/etc/os-version")
 find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS Gui)
 find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS Core)
@@ -34,7 +34,7 @@ if("${QT_VERSION_MAJOR}" STREQUAL "6")
   find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS Core5Compat)
 endif()
 
-# start base 
+# start base
 include(../src/base/base.cmake)
 
 # end base
@@ -46,15 +46,15 @@ include(../src/dci/dci.cmake)
 #start filesystem
 include(../src/filesystem/filesystem.cmake)
 #end filesystem
-# start log 
+# start log
 include(../src/log/log.cmake)
 #end log
-# start settings 
+# start settings
 include(../src/settings/settings.cmake)
 #message(${settings_SRC})
 #end settings
 
-#start utils 
+#start utils
 
 # TODO match linux and others
 include(../src/util/util.cmake)
@@ -68,19 +68,19 @@ include(../src/glob.cmake)
 # for test.so
 add_subdirectory(./testso)
 
-# test 
+# test
 file(GLOB TEST_HEADER
-  ut_.*h 
+  ut_.*h
 )
 file(GLOB TEST_SOURCE
-  *.cpp 
+  *.cpp
 )
 
 if("${QT_VERSION_MAJOR}" STREQUAL "6")
   list(REMOVE_ITEM TEST_SOURCE "${CMAKE_CURRENT_LIST_DIR}/ut_gsettingsbackend.cpp")
 endif()
 
-set(test_SRC 
+set(test_SRC
   ${TEST_HEADER}
   ${TEST_SOURCE}
 )
@@ -91,7 +91,7 @@ if(LINUX)
     ${base_SRCS}
     ${dci_SRCS}
     ${filesystem_SRCS}
-    ${log_SRCS}	
+    ${log_SRCS}
     ${settings_SRC}
     ${utils_SRC}
     ${glob_SRC}
@@ -110,7 +110,7 @@ if(LINUX)
     Qt${QT_VERSION_MAJOR}::Test
     ${GTEST_LIBRARIES}
     -lpthread
-    -lm 
+    -lm
     -lgcov
     -lvtabletest
     -ldl
@@ -179,7 +179,7 @@ else()
     Qt${QT_VERSION_MAJOR}::Test
     ${GTEST_LIBRARIES}
     -lpthread
-    -lm 
+    -lm
     -lgcov
     -lvtabletest
   )


### PR DESCRIPTION
 * BUILD_VERSION should be a string, not a boolean option;
 * Should use CMAKE_INSTALL_PREFIX as DSG_PREFIX_PATH in test, CMAKE_PREFIX_PATH might be a list. And there's difference between two variables;
 * Trim some trailing spaces.

Log: fix wrong use of option and wrong macro