### PR TITLE
fix: DConfig's `subpathIsValid` produces error

### DIFF
--- a/src/dconfigfile.cpp
+++ b/src/dconfigfile.cpp
@@ -43,7 +43,7 @@ inline static bool subpathIsValid(const QString &subpath, const QDir &dir)
         return true;
 
     const QDir subDir(dir.filePath(subpath.mid(1)));
-    return subDir.canonicalPath().startsWith(dir.canonicalPath());
+    return subDir.absolutePath().startsWith(dir.absolutePath());
 }
 /*!
 @~english

--- a/tests/ut_dconfigfile.cpp
+++ b/tests/ut_dconfigfile.cpp
@@ -460,3 +460,28 @@ TEST_F(ut_DConfigFile, setCachePathPrefix) {
         ASSERT_EQ(config.value("key3", userCache.get()), QString("global-config"));
     }
 }
+
+TEST_F(ut_DConfigFile, setSubpath) {
+
+    FileCopyGuard guard(":/data/dconf-example.meta.json", QString("%1/%2.json").arg(metaPath, FILE_NAME));
+    {
+        DConfigFile config(APP_ID, FILE_NAME);
+        ASSERT_TRUE(config.load(LocalPrefix));
+    }
+    {
+        DConfigFile config(APP_ID, FILE_NAME, "/a/b");
+        ASSERT_TRUE(config.load(LocalPrefix));
+    }
+    {
+        DConfigFile config(APP_ID, FILE_NAME, "/a/b/..");
+        ASSERT_TRUE(config.load(LocalPrefix));
+    }
+    {
+        DConfigFile config(APP_ID, FILE_NAME, "/../a/b");
+        ASSERT_FALSE(config.load(LocalPrefix));
+    }
+    {
+        DConfigFile config(APP_ID, FILE_NAME, "/a/b/../../..");
+        ASSERT_FALSE(config.load(LocalPrefix));
+    }
+}


### PR DESCRIPTION
  It's correctly even if subpath is not exist, so we can't use
`QDir::canonicalPath` to adjust subpath.
  Add ut.