### PR TITLE
fix: DTextEncoding ut failed in Qt6.

### DIFF
--- a/docs/util/dtextencoding.zh_CN.dox
+++ b/docs/util/dtextencoding.zh_CN.dox
@@ -25,7 +25,7 @@
 
 @fn bool Dtk::Core::DTextEncoding::convertTextEncoding(QByteArray &content, QByteArray &outContent, const QByteArray &toEncoding, const QByteArray &fromEncoding, QString *errString)
 @brief 将输入的文本 `content` 从 `fromEncoding` 编码格式转换到 `toEncoding` 编码格式，转换后的文本保存到 `outContent` 。
-    若转换过程中出现错误，将返回 false , 并设置 `errString` 错误信息。
+    若转换过程中出现错误，将返回 false , 并设置 `errString` 错误信息，已转换的文本仍会写入 `outContent` 。
 @note 当处理大量文本数据时，需考虑并行处理，防止阻塞线程。
 @param[in] content 传入的文本
 @param[out] outContent 编码转换后的文本 
@@ -33,10 +33,24 @@
 @param[in] fromEncoding 原始的编码格式，默认为空，会通过 `DTextEncoding::detectTextEncoding` 检测编码格式
 @param[out] errString 错误信息
 @return 是否转换成功
+@sa DTextEncoding::convertTextEncodingEx
+
+@fn bool Dtk::Core::DTextEncoding::convertTextEncodingEx(QByteArray &content, QByteArray &outContent, const QByteArray &toEncoding, const QByteArray &fromEncoding, QString *errString, int *convertedBytes)
+@brief 将输入的文本 `content` 从 `fromEncoding` 编码格式转换到 `toEncoding` 编码格式，转换后的文本保存到 `outContent` 。
+    若转换过程中出现错误，将返回 false , 并设置 `errString` 错误信息，已转换的文本仍会写入 `outContent` 。
+@note 当处理大量文本数据时，需考虑并行处理，防止阻塞线程。
+@note 返回 false 时，已转换的文本仍会写入 `outContent` ，同时 `convertedBytes` 会记录已转换数据长度，你可以决定保留或移除转换文本。
+@param[in] content 传入的文本
+@param[out] outContent 编码转换后的文本 
+@param[in] toEncoding 转换的编码格式
+@param[in] fromEncoding 原始的编码格式，默认为空，会通过 `DTextEncoding::detectTextEncoding` 检测编码格式
+@param[out] errString 错误信息
+@param[out] convertedBytes 已转换的 `content` 数据长度，若转换过程出现错误，这个值会指向异常字符出现的位置
+@return 是否转换成功
 
 @fn bool DTextEncoding::convertFileEncoding(const QString &fileName, const QByteArray &toEncoding, const QByteArray &fromEncoding, QString *errString)
 @brief 读取输入的 `fileName` 文件内容，将文件内容从 `fromEncoding` 编码格式转换到 `toEncoding` 编码格式，转换后的文本保存到 `fileName` 。
-    若转换过程中出现错误，将返回 false , 并设置 `errString` 错误信息。
+    若转换过程中出现错误，将返回 false , 并设置 `errString` 错误信息，已转换的文本会被抛弃。
 @param[in] fileName 传入及保存的文件路径
 @param[in] toEncoding 转换的编码格式
 @param[in] fromEncoding 原始的编码格式，为空时会通过 `DTextEncoding::detectTextEncoding` 检测编码格式
@@ -46,7 +60,7 @@
 
 @fn bool DTextEncoding::convertFileEncodingTo(const QString &fromFile, const QString &toFile, const QByteArray &toEncoding, const QByteArray &fromEncoding, QString *errString)
 @brief 读取输入的 `fromFile` 文件内容，将文件内容从 `fromEncoding` 编码格式转换到 `toEncoding` 编码格式，转换后的文本保存到 `toFile` 。
-    若转换过程中出现错误，将返回 false , 并设置 `errString` 错误信息。
+    若转换过程中出现错误，将返回 false , 并设置 `errString` 错误信息，已转换的文本会被抛弃。
 @param[in] fromFile 传入的文件路径
 @param[in] toFile 保存的文件路径
 @param[in] toEncoding 转换的编码格式

--- a/include/util/dtextencoding.h
+++ b/include/util/dtextencoding.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022-2023 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
@@ -23,6 +23,12 @@ public:
                                     const QByteArray &toEncoding,
                                     const QByteArray &fromEncoding = QByteArray(),
                                     QString *errString = nullptr);
+    static bool convertTextEncodingEx(QByteArray &content,
+                                      QByteArray &outContent,
+                                      const QByteArray &toEncoding,
+                                      const QByteArray &fromEncoding = QByteArray(),
+                                      QString *errString = nullptr,
+                                      int *convertedBytes = nullptr);
     static bool convertFileEncoding(const QString &fileName,
                                     const QByteArray &toEncoding,
                                     const QByteArray &fromEncoding = QByteArray(),

--- a/tests/ut_dtextencoding.cpp
+++ b/tests/ut_dtextencoding.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022-2023 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
@@ -8,7 +8,13 @@
 
 #include <QLibrary>
 #include <QFile>
+#include <QTemporaryFile>
+
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+#include <QStringConverter>
+#else
 #include <QTextCodec>
+#endif
 
 DCORE_USE_NAMESPACE
 
@@ -34,10 +40,18 @@ protected:
 
 bool ut_DTextEncoding::canLoadUchardet = false;
 bool ut_DTextEncoding::canLoadICU = false;
-QString ut_DTextEncoding::tmpFileName = QString("/tmp/ut_DTextEncoding_temp.txt");
-QByteArray ut_DTextEncoding::dataGB18030;
-QByteArray ut_DTextEncoding::dataEUC_JP;
-QByteArray ut_DTextEncoding::dataKOI8_R;
+QString ut_DTextEncoding::tmpFileName;
+// Utf8 Chinese Text(Hex): 中文测试一二三四123456789abcdefgh
+QByteArray ut_DTextEncoding::dataGB18030 = "\xd6\xd0\xce\xc4\xb2\xe2\xca\xd4\xd2\xbb\xb6\xfe\xc8\xfd\xcb\xc4\x31\x32\x33\x34\x35"
+                                           "\x36\x37\x38\x39\x61\x62\x63\x64\x65\x66\x67\x68";
+// Utf8 Japanese Text(Hex): 日本語のテスト ワン ツー スリー フォー 123456789abcdefgh
+QByteArray ut_DTextEncoding::dataEUC_JP =
+    "\xc6\xfc\xcb\xdc\xb8\xec\xa4\xce\xa5\xc6\xa5\xb9\xa5\xc8\x20\xa5\xef\xa5\xf3\x20\xa5\xc4\xa1\xbc\x20\xa5\xb9\xa5\xea\xa1\xbc"
+    "\x20\xa5\xd5\xa5\xa9\xa1\xbc\x20\x31\x32\x33\x34\x35\x36\x37\x38\x39\x61\x62\x63\x64\x65\x66\x67\x68";
+// Utf8 Russian Text(Hex): Русский тест раз два три четыре 123456789abcdefgh
+QByteArray ut_DTextEncoding::dataKOI8_R =
+    "\xf2\xd5\xd3\xd3\xcb\xc9\xca\x20\xd4\xc5\xd3\xd4\x20\xd2\xc1\xda\x20\xc4\xd7\xc1\x20\xd4\xd2\xc9\x20\xde\xc5\xd4\xd9\xd2\xc5"
+    "\x20\x31\x32\x33\x34\x35\x36\x37\x38\x39\x61\x62\x63\x64\x65\x66\x67\x68";
 
 void ut_DTextEncoding::SetUpTestCase()
 {
@@ -56,40 +70,16 @@ void ut_DTextEncoding::SetUpTestCase()
             icuuc.unload();
         }
     }
-
-    // Utf8 Text: 中文测试一二三四123456789abcdefgh
-    const QByteArray chineseUnicode("\u4e2d\u6587\u6d4b\u8bd5\u4e00\u4e8c\u4e09\u56db\u0031\u0032\u0033\u0034\u0035\u0036\u0037"
-                                    "\u0038\u0039\u0061\u0062\u0063\u0064\u0065\u0066\u0067\u0068");
-    // Utf8 Text: 日本語のテスト ワン ツー スリー フォー 123456789abcdefgh
-    const QByteArray japaneseUnicode(
-        "\u65e5\u672c\u8a9e\u306e\u30c6\u30b9\u30c8\u0020\u30ef\u30f3\u0020\u30c4\u30fc\u0020\u30b9\u30ea\u30fc\u0020\u30d5\u30a9"
-        "\u30fc\u0020\u0031\u0032\u0033\u0034\u0035\u0036\u0037\u0038\u0039\u0061\u0062\u0063\u0064\u0065\u0066\u0067\u0068");
-    // Utf8 Text: Русский тест раз два три четыре 123456789abcdefgh
-    const QByteArray russianUnicode(
-        "\u0420\u0443\u0441\u0441\u043a\u0438\u0439\u0020\u0442\u0435\u0441\u0442\u0020\u0440\u0430\u0437\u0020\u0434\u0432\u0430"
-        "\u0020\u0442\u0440\u0438\u0020\u0447\u0435\u0442\u044b\u0440\u0435\u0020\u0031\u0032\u0033\u0034\u0035\u0036\u0037\u0038"
-        "\u0039\u0061\u0062\u0063\u0064\u0065\u0066\u0067\u0068");
-
-    QTextCodec *codec = QTextCodec::codecForName("GB18030");
-    if (codec) {
-        dataGB18030 = codec->fromUnicode(QString::fromUtf8(chineseUnicode));
-    }
-    codec = QTextCodec::codecForName("EUC-JP");
-    if (codec) {
-        dataEUC_JP = codec->fromUnicode(QString::fromUtf8(japaneseUnicode));
-    }
-    codec = QTextCodec::codecForName("KOI8-R");
-    if (codec) {
-        dataKOI8_R = codec->fromUnicode(QString::fromUtf8(russianUnicode));
-    }
 }
 
 bool ut_DTextEncoding::rewriteTempFile(const QByteArray &data)
 {
-    QFile tmpFile(tmpFileName);
-    if (!tmpFile.open(QFile::WriteOnly | QFile::Truncate)) {
+    QTemporaryFile tmpFile;
+    if (!tmpFile.open()) {
         return false;
     }
+    tmpFileName = tmpFile.fileName();
+    tmpFile.setAutoRemove(false);
 
     tmpFile.write(data);
     tmpFile.close();
@@ -123,9 +113,14 @@ TEST_F(ut_DTextEncoding, testDetectTextEncodeWithUchardet)
 {
     if (canLoadUchardet) {
         QByteArray uchardetEncoding("EUC-TW");
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+        auto encode = QStringConverter::encodingForName(uchardetEncoding);
+        ASSERT_FALSE(encode);
+#else
         // QTextCodec not suppotted EUC-TW.
         QTextCodec *codec = QTextCodec::codecForName(uchardetEncoding);
         ASSERT_EQ(codec, nullptr);
+#endif
 
         // Utf8 text: 繁體中文測試一二三四
         QByteArray dataZhTraditional("\u7e41\u9ad4\u4e2d\u6587\u6e2c\u8a66\u4e00\u4e8c\u4e09\u56db");
@@ -169,19 +164,31 @@ TEST_F(ut_DTextEncoding, testConvertTextEncoding)
     QByteArray dataUTF_8;
     ASSERT_TRUE(DTextEncoding::convertTextEncoding(dataGB18030, dataUTF_8, "UTF-8"));
     ASSERT_EQ("UTF-8", DTextEncoding::detectTextEncoding(dataUTF_8));
+
+    // QStringConverter not support GB18030.
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
     QTextCodec *codec = QTextCodec::codecForName("GB18030");
     ASSERT_EQ(codec->toUnicode(dataGB18030).toUtf8(), dataUTF_8);
 
     QByteArray convertedGB18030;
     ASSERT_TRUE(DTextEncoding::convertTextEncoding(dataUTF_8, convertedGB18030, "GB18030"));
     ASSERT_EQ(dataGB18030, convertedGB18030);
+#endif
 
     // Convert with multi bytes encoding.
     QByteArray dataUTF_16;
     ASSERT_TRUE(DTextEncoding::convertTextEncoding(dataUTF_8, dataUTF_16, "UTF-16"));
     ASSERT_EQ("UTF-16", DTextEncoding::detectTextEncoding(dataUTF_16));
+
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+    // Qt6 using utf-16 string by default, not utf-8.
+    auto fromUtf16 = QStringDecoder(QStringDecoder::Utf16);
+    QString strUtf16 = fromUtf16.decode(dataUTF_16);
+    ASSERT_EQ(strUtf16, QString::fromUtf8(dataUTF_8));
+#else
     codec = QTextCodec::codecForName("UTF-16");
     ASSERT_EQ(codec->toUnicode(dataUTF_16).toUtf8(), dataUTF_8);
+#endif
 
     QByteArray convertedUTF8;
     ASSERT_TRUE(DTextEncoding::convertTextEncoding(dataUTF_16, convertedUTF8, "UTF-8"));
@@ -190,10 +197,16 @@ TEST_F(ut_DTextEncoding, testConvertTextEncoding)
     QByteArray dataUTF_32;
     ASSERT_TRUE(DTextEncoding::convertTextEncoding(dataUTF_8, dataUTF_32, "UTF-32"));
     ASSERT_EQ("UTF-32", DTextEncoding::detectTextEncoding(dataUTF_32));
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+    auto fromUtf32 = QStringDecoder(QStringDecoder::Utf32);
+    QString strUtf32 = fromUtf32.decode(dataUTF_32);
+    ASSERT_EQ(strUtf32, QString::fromUtf8(dataUTF_8));
+#else
     codec = QTextCodec::codecForName("UTF-32");
     ASSERT_EQ(codec->toUnicode(dataUTF_32).toUtf8(), dataUTF_8);
+#endif
 
-    ASSERT_TRUE(DTextEncoding::convertTextEncoding(dataUTF_16, convertedUTF8, "UTF-8"));
+    ASSERT_TRUE(DTextEncoding::convertTextEncoding(dataUTF_32, convertedUTF8, "UTF-8"));
     ASSERT_EQ(dataUTF_8, convertedUTF8);
 }
 
@@ -202,6 +215,21 @@ TEST_F(ut_DTextEncoding, testConvertTextEncodingWithError)
     QByteArray dataUTF_8;
     ASSERT_FALSE(DTextEncoding::convertTextEncoding(dataGB18030, dataUTF_8, "ERROR"));
     ASSERT_FALSE(DTextEncoding::convertTextEncoding(dataGB18030, dataUTF_8, "KOI8-R"));
+
+    QByteArray tmpUTF_8Error = "\x31\x32\x33\xFF\xFF\xFF\x31\x32\x33";
+    QByteArray tmpUTF_16;
+    QString error;
+    int converted = 0;
+    bool ret = DTextEncoding::convertTextEncodingEx(tmpUTF_8Error, tmpUTF_16, "UTF-16", "UTF-8", &error, &converted);
+    ASSERT_FALSE(ret);
+    ASSERT_FALSE(error.isEmpty());
+    ASSERT_EQ(converted, 3);
+
+    QByteArray tmpUTF_8Error2 = "\xFF\xFF";
+    converted = 3;
+    ret = DTextEncoding::convertTextEncodingEx(tmpUTF_8Error2, tmpUTF_16, "UTF-16", "UTF-8", &error, &converted);
+    ASSERT_FALSE(ret);
+    ASSERT_EQ(converted, 0);
 }
 
 TEST_F(ut_DTextEncoding, testConvertFileEncoding)
@@ -219,6 +247,10 @@ TEST_F(ut_DTextEncoding, testConvertFileEncoding)
 TEST_F(ut_DTextEncoding, testConvertFileEncodingTo)
 {
     QString tmpConvertFileName("/tmp/ut_DTextEncoding_temp_testConvertFileEncodingTo.txt");
+    if (QFile::exists(tmpConvertFileName)) {
+        ASSERT_TRUE(QFile::remove(tmpConvertFileName));
+    }
+
     ASSERT_TRUE(rewriteTempFile(dataGB18030));
     ASSERT_TRUE(DTextEncoding::convertFileEncodingTo(tmpFileName, tmpConvertFileName, "GB18030"));
     ASSERT_TRUE(QFile::exists(tmpConvertFileName));
@@ -236,6 +268,10 @@ TEST_F(ut_DTextEncoding, testConvertFileEncodingTo)
 TEST_F(ut_DTextEncoding, testConvertFileEncodingToWithError)
 {
     QString tmpConvertFileName("/tmp/ut_DTextEncoding_temp_testConvertFileEncodingToWithError.txt");
+    if (QFile::exists(tmpConvertFileName)) {
+        ASSERT_TRUE(QFile::remove(tmpConvertFileName));
+    }
+
     ASSERT_FALSE(DTextEncoding::convertFileEncodingTo("", tmpConvertFileName, "UTF-32"));
     ASSERT_FALSE(DTextEncoding::convertFileEncodingTo(tmpFileName, "", "UTF-32"));
     ASSERT_FALSE(DTextEncoding::convertFileEncodingTo(tmpFileName, tmpConvertFileName, "ERROR"));


### PR DESCRIPTION
1. Fix DTextEncoding muti-byte encoding calculation error.
2. Replace QTextCodec with QStringConverter in Qt6 env.
3. Add convertedBytes param in the convertTextEncodinig() interface.

Log: Fix DTextEncoding ut failed in Qt6.