### PR TITLE
fix: qdbusxml2cpp-fix not in path

### DIFF
--- a/cmake/DtkTools/DtkToolsConfig.cmake.in
+++ b/cmake/DtkTools/DtkToolsConfig.cmake.in
@@ -1,4 +1,5 @@
-find_package(Dtk@DTK_VERSION_MAJOR@Core REQUIRED)
+include(CMakeFindDependencyMacro)
+find_dependency(Dtk@DTK_VERSION_MAJOR@Core REQUIRED)
 
 set (DTK_SETTINGS_TOOLS_EXECUTABLE ${DtkCore_TOOL_DIRS}/dtk-settings)
 
@@ -7,3 +8,6 @@ if (EXISTS ${DTK_SETTINGS_TOOLS_EXECUTABLE})
 endif ()
 
 include("${CMAKE_CURRENT_LIST_DIR}/DtkSettingsToolsMacros.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/DtkToolsTargets.cmake")
+
+get_target_property(DTK_XML2CPP Dtk@DTK_VERSION_MAJOR@::Xml2Cpp LOCATION)

--- a/tools/qdbusxml2cpp/CMakeLists.txt
+++ b/tools/qdbusxml2cpp/CMakeLists.txt
@@ -6,7 +6,7 @@ find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS Core)
 find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS DBus)
 
 add_executable(${BIN_NAME}
-  qdbusxml2cpp.cpp 
+  qdbusxml2cpp.cpp
 )
 
 target_link_libraries(
@@ -15,6 +15,22 @@ target_link_libraries(
   Qt${QT_VERSION_MAJOR}::Core
   Qt${QT_VERSION_MAJOR}::DBusPrivate
 )
-set_target_properties(${BIN_NAME} PROPERTIES OUTPUT_NAME ${TARGET_NAME})
-install(TARGETS ${BIN_NAME} DESTINATION "${TOOL_INSTALL_DIR}")
 
+set_target_properties(
+  ${BIN_NAME} PROPERTIES
+  OUTPUT_NAME ${TARGET_NAME}
+  EXPORT_NAME Xml2Cpp
+)
+
+install(
+  TARGETS ${BIN_NAME}
+  EXPORT DtkToolsTargets
+  DESTINATION ${TOOL_INSTALL_DIR}
+)
+
+install(
+  EXPORT DtkToolsTargets
+  FILE DtkToolsTargets.cmake
+  NAMESPACE Dtk${DTK_VERSION_MAJOR}::
+  DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/Dtk${DTK_VERSION_MAJOR}Tools"
+)


### PR DESCRIPTION
Now qdbusxml2cpp-fix is not in PATH, just export it as a target so others can use it.

Log: fix qdbusxml2cpp-fix not in path