### PR TITLE
chore: remove ddbusinterface property cache

### DIFF
--- a/src/util/ddbusinterface.cpp
+++ b/src/util/ddbusinterface.cpp
@@ -72,7 +72,7 @@ void DDBusInterfacePrivate::updateProp(const char *propName, const QVariant &val
 {
     if (!m_parent)
         return;
-    m_propertyMap.insert(propName, value);
+
     const QMetaObject *metaObj = m_parent->metaObject();
     const char *typeName(value.typeName());
     void *data = const_cast<void *>(value.data());
@@ -246,8 +246,6 @@ inline QString originalPropname(const char *propname, QString suffix)
 QVariant DDBusInterface::property(const char *propName)
 {
     Q_D(DDBusInterface);
-    if (d->m_propertyMap.contains(propName))
-        return d->m_propertyMap.value(propName);
 
     QDBusMessage msg = QDBusMessage::createMethodCall(service(), path(), PropertiesInterface, QStringLiteral("Get"));
     msg << interface() << originalPropname(propName, d->m_suffix);
@@ -265,7 +263,6 @@ QVariant DDBusInterface::property(const char *propName)
             QMetaProperty metaProperty = metaObject->property(i);
             // try to use property in parent to unwrap the value
             propresult = demarshall(metaProperty, propresult);
-            d->m_propertyMap.insert(propName, propresult);
         }
         return propresult;
     }
@@ -273,8 +270,6 @@ QVariant DDBusInterface::property(const char *propName)
     QDBusPendingCallWatcher *watcher = new QDBusPendingCallWatcher(prop, this);
     watcher->setProperty(PropertyName, propName);
     connect(watcher, &QDBusPendingCallWatcher::finished, d, &DDBusInterfacePrivate::onAsyncPropertyFinished);
-    if (d->m_propertyMap.contains(propName))
-        return d->m_propertyMap.value(propName);
 
     return QVariant();
 }

--- a/src/util/ddbusinterface_p.h
+++ b/src/util/ddbusinterface_p.h
@@ -29,7 +29,6 @@ private Q_SLOTS:
 public:
     QObject *m_parent;
     QString m_suffix;
-    QVariantMap m_propertyMap;
     bool m_serviceValid;
 
     DDBusInterface *q_ptr;


### PR DESCRIPTION
有的服务属性改变时不会发送 ProperiesChanged 导致属性变化后再次
获取属性时还是旧的 value ，因为缓存不会更新