### PR TITLE
chore: remove libdtkcommon depends

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -10,7 +10,7 @@ Standards-Version: 3.9.8
 
 Package: libdtkcore5
 Architecture: any
-Depends: ${shlibs:Depends}, ${misc:Depends}, lshw, libdtkcommon
+Depends: ${shlibs:Depends}, ${misc:Depends}, lshw
 Multi-Arch: same
 Description: Deepin Tool Kit Core library
  DtkCore is base library of Deepin Qt/C++ applications.


### PR DESCRIPTION
libdtkcore5 does not depend libdtkcommon