### PR TITLE
feat(dstandardpaths): add XDG_STATE_HOME

### DIFF
--- a/docs/filesystem/dstandardpaths.zh_CN.dox
+++ b/docs/filesystem/dstandardpaths.zh_CN.dox
@@ -1,0 +1,47 @@
+/*!
+@~chinese
+@ingroup dfilesystem
+@file include/filesystem/dstandardpaths.h
+
+@class DStandardPaths
+@brief DStandardPaths 类描述了一些标准的文件路径，包括XDG文件路径，locate等
+
+@fn static QString DStandardPaths::writableLocation(QStandardPaths::StandardLocation type)
+@brief DStandardPaths提供兼容Snap/Dtk标准的路径模式。DStandardPaths实现了Qt的QStandardPaths主要接口。此处返回可写路径
+
+@fn static QStringList DStandardPaths::standardLocations (QStandardPaths::StandardLocation type)
+@brief DStandardPaths提供兼容Snap/Dtk标准的路径模式。DStandardPaths实现了Qt的QStandardPaths主要接口。此处返回所有Standardpath
+
+@fn static QString DStandardPaths::locate(QStandardPaths::StandardLocation type, const QString &fileName, QStandardPaths::LocateOptions options = QStandardPaths::LocateFile)
+@brief 在 type 的标准位置查找名为 fileName 的文件或目录。选项标志允许您指定是否查找文件或目录。默认情况下，此标志设置为 LocateFile。返回找到的第一个文件或目录的绝对路径，否则返回空字符串。
+
+@fn static QStringList DStandardPaths::locateAll(QStandardPaths::StandardLocation type, const QString &fileName, QStandardPaths::LocateOptions options = QStandardPaths::LocateFile)
+@brief 在类型的标准位置中按名称 fileName 查找所有文件或目录。选项标志允许您指定是否查找文件或目录。默认情况下，此标志设置为 LocateFile。返回找到的所有文件的列表。
+
+@fn static QString DStandardPaths::findExecutable(const QString &executableName, const QStringList &paths = QStringList())
+@brief 同QStandardPaths::findExecutable, 查找可执行文件
+
+@fn static void DStandardPaths::setMode(DStandardPaths::Mode mode)
+@brief 同QStandardPaths::setTestModeEnabled, 设置是否是测试模式
+
+@fn static QString DStandardPaths::homePath()
+@brief 返回家目录
+
+@fn static QString DStandardPaths::homePath(const uint uid)
+@brief 用uid返回家目录
+
+@fn static QString DStandardPaths::path(DStandardPaths::XDG type)
+@brief 返回对应的xdg目录
+
+@fn static QString DStandardPaths::path(DStandardPaths::DSG type)
+@brief 返回对应Dsg目录
+
+@fn static QStringList DStandardPaths::paths(DStandardPaths::DSG type)
+@brief 返回所有DSG下所有目录
+
+@fn static QString DStandardPaths::filePath(DStandardPaths::XDG type, QString fileName)
+@brief 用xdg和文件名称拼接，返回文件绝对路径
+
+@fn static QString DStandardPaths::filePath(DStandardPaths::DSG type, QString fileName)
+@brief 用dsg和文件名称拼接，返回文件绝对路径
+*/

--- a/include/filesystem/dstandardpaths.h
+++ b/include/filesystem/dstandardpaths.h
@@ -29,14 +29,33 @@ public:
     static QString findExecutable(const QString &executableName, const QStringList &paths = QStringList());
     static void setMode(Mode mode);
 
+    /**
+     * @brief About XDG dir, view it in https://gitlab.freedesktop.org/xdg/xdg-specs/
+     */
     enum class XDG {
+        /*
+         * @brief DataHome, usually is ~/.local/share, also can be defined by ${XDG_DATA_HOME}, where stores the data of applications
+         */
         DataHome,
+        /*
+         * @brief ConfigHome, usually is ~/.config, can be defined by ${XDG_CONFIG_HOME}, where stores the config of applications
+         */
         ConfigHome,
+        /*
+         * @brief CacheHome, usually is ~/.cache, can be defined by ${XDG_CACHE_HOME}, where stores caches, can be always cleared
+         */
         CacheHome,
+        /*
+         * @brief Where temp files or sock files always be put in, like sddm.sock. It is unique per session. It is /run/user/${uid} or ${XDG_RUNTIME_DIR},
+         */
         RuntimeDir,
 #if DTK_VERSION < DTK_VERSION_CHECK(6, 0, 0, 0)
-        RuntimeTime [[deprecated("Use RuntimeDir Instead")]] = RuntimeDir
+        RuntimeTime [[deprecated("Use RuntimeDir Instead")]] = RuntimeDir,
 #endif
+        /*
+         * @brief where history file and state file should be. It is induced because users do not want to mix their config files and state files. It is always ~/.local/state, or defined by ${XDG_STATE_HOME}
+         */
+        StateHome
     };
 
     enum class DSG {
@@ -46,6 +65,9 @@ public:
 
     static QString homePath();
     static QString homePath(const uint uid);
+    /*
+     * @brief Get the XDG dir path by XDG type
+     */
     static QString path(XDG type);
     static QString path(DSG type);
     static QStringList paths(DSG type);

--- a/src/filesystem/dstandardpaths.cpp
+++ b/src/filesystem/dstandardpaths.cpp
@@ -148,6 +148,17 @@ QString DStandardPaths::path(DStandardPaths::XDG type)
             return QString::fromLocal8Bit(path);
         return QStringLiteral("/run/user/") + QString::number(getuid());
     }
+    case XDG::StateHome: {
+        const QByteArray &path = qgetenv("XDG_STATE_HOME");
+        if (!path.isEmpty())
+            return QString::fromLocal8Bit(path);
+#ifdef Q_OS_LINUX
+        return homePath() + QStringLiteral("/.local/state");
+#else
+        // TODO: handle it on mac
+        return QString();
+#endif
+    }
     }
     return QString();
 }


### PR DESCRIPTION
this folder is used to storage history and logs

Log:

ref: https://gitlab.freedesktop.org/xdg/xdg-specs/-/commit/4f2884e16db35f2962d9b64312917c81be5cb54b