### PR TITLE
add ut for DDbusSender

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,4 +1,5 @@
-set(BIN_NAME "ut-${LIB_NAME}")
+# 方便 test 脚本中调用
+set(BIN_NAME "ut-DtkCore")
 
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)

--- a/tests/fakedbus/fakedbusservice.h
+++ b/tests/fakedbus/fakedbusservice.h
@@ -6,6 +6,7 @@
 
 #include <QStringList>
 #include <QDBusObjectPath>
+
 #include <ddbusinterface.h>
 
 using Dtk::Core::DDBusInterface;
@@ -32,21 +33,29 @@ public:
     explicit FakeDBusService(QObject *parent = nullptr);
     ~FakeDBusService();
 
-    Q_PROPERTY(QString strProperty READ strproperty)
-    inline QString strproperty() { return m_strproperty; }
-
-    Q_PROPERTY(QList<QDBusObjectPath> objectPaths READ objectpaths);
-    inline QList<QDBusObjectPath> objectpaths() { return m_objectpaths; }
+    Q_PROPERTY(QString strProperty READ strproperty WRITE setStrproperty)
+    Q_PROPERTY(QList<QDBusObjectPath> objectPaths READ objectpaths)
 
     static QString get_service() { return "org.deepin.FakeDBusService"; }
     static QString get_path() { return "/org/deepin/FakeDBusService"; }
     static QString get_interface() { return "org.deepin.FakeDBusService"; }
 
+public Q_SLOTS:
+    inline QString strproperty() { return m_strproperty; }
+    void setStrproperty(const QString &var) {
+        if (var != m_strproperty)
+            m_strproperty = var;
+    }
+    inline QList<QDBusObjectPath> objectpaths() { return m_objectpaths; }
+    // ExportScriptableContents
+    Q_SCRIPTABLE QString foo() { return QString("bar"); }
+
 private:
     const QString m_service{"org.deepin.FakeDBusService"};
     const QString m_path{"/org/deepin/FakeDBusService"};
-    QString m_strproperty;
-    QList<QDBusObjectPath> m_objectpaths;
     void registerService();
     void unregisterService();
+
+    QString m_strproperty;
+    QList<QDBusObjectPath> m_objectpaths;
 };

--- a/tests/test-recoverage.sh
+++ b/tests/test-recoverage.sh
@@ -3,6 +3,7 @@
 # SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
 #
 # SPDX-License-Identifier: LGPL-3.0-or-later
+set -e
 
 BUILD_DIR=`pwd`/../build/tests/
 HTML_DIR=${BUILD_DIR}/html

--- a/tests/ut_ddbussender.cpp
+++ b/tests/ut_ddbussender.cpp
@@ -1,0 +1,69 @@
+// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#include <gtest/gtest.h>
+#include "ddbussender.h"
+
+#include <QtDBus>
+#include <QDebug>
+
+#include "fakedbus/fakedbusservice.h"
+
+using Dtk::Core::DDBusInterface;
+
+class ut_DDBusSender : public testing::Test
+{
+public:
+    void SetUp() override
+    {
+        m_testservice = new FakeDBusService();
+        m_sender = new DDBusSender;
+    }
+    void TearDown() override
+    {
+        delete m_testservice;
+        delete m_sender;
+    }
+
+    FakeDBusService *m_testservice = nullptr;
+    DDBusSender *m_sender = nullptr;
+};
+
+
+TEST_F(ut_DDBusSender, DDBusCaller)
+{
+    QDBusPendingReply<QString> reply = m_sender->service(m_testservice->get_service())
+            .path(m_testservice->get_path())
+            .interface(m_testservice->get_interface())
+            .method(QString("foo"))
+            .call();
+
+    reply.waitForFinished();
+    if (reply.error().isValid())
+        qWarning() << reply.error().message();
+
+    ASSERT_TRUE(reply.value() == QString("bar"));
+}
+
+TEST_F(ut_DDBusSender, DDBusProperty)
+{
+    auto prop = m_sender->service(m_testservice->get_service())
+            .path(m_testservice->get_path())
+            .interface(m_testservice->get_interface())
+            .property(QString("strProperty"));
+
+    QDBusPendingReply<QVariant> reply = prop.get();
+    reply.waitForFinished();
+    if (reply.error().isValid())
+        qWarning() << reply.error().message();
+
+    ASSERT_TRUE(reply.value().toString() == QString("testDBusService"));
+
+    auto res = prop.set("myProp");
+    res.waitForFinished();
+    if (res.error().isValid())
+        qWarning() << res.error().message();
+
+    ASSERT_TRUE(m_testservice->strproperty() ==  QString("myProp"));
+}


### PR DESCRIPTION
### make test-recoverage.sh runable again
 - set -e : exit if command has a non-zero exit status
 - fix test target name ut-DtkCore
### chore: add ut for DDbusSender
- tweek FakeDBusService. add metho and read/write propery
- test DDbusSender. call dbus method and get/set dbus property