### PR TITLE
fix: incorrect version passed to cmake in build

### DIFF
--- a/archlinux/PKGBUILD
+++ b/archlinux/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: justforlxz <justforlxz@gmail.com>
 pkgname=dtkcore-git
-pkgver=5.5.23.r5.g74f86b0
+pkgver=5.6.16
 pkgrel=1
 sourcename=dtkcore
 sourcetars=("$sourcename"_"$pkgver".tar.xz)
@@ -19,16 +19,19 @@ sha512sums=('SKIP')
 
 build() {
   cd $sourcedir
-  cmake -GNinja \
-      -DMKSPECS_INSTALL_DIR=lib/qt/mkspecs/modules/\
-      -DBUILD_DOCS=ON \
-      -DBUILD_EXAMPLES=OFF \
-      -DQCH_INSTALL_DESTINATION=share/doc/qt \
-      -DCMAKE_INSTALL_LIBDIR=lib \
-      -DCMAKE_INSTALL_PREFIX=/usr \
-      -DCMAKE_BUILD_TYPE=Release \
-      -DD_DSG_APP_DATA_FALLBACK=/var/dsg/appdata \
-      -DBUILD_WITH_SYSTEMD=ON
+  version=$(echo $pkgver | awk -F'[+_~-]' '{print $1}')
+  cmake \
+    -GNinja \
+    -DMKSPECS_INSTALL_DIR=lib/qt/mkspecs/modules \
+    -DBUILD_DOCS=ON \
+    -DBUILD_EXAMPLES=OFF \
+    -DQCH_INSTALL_DESTINATION=share/doc/qt \
+    -DCMAKE_INSTALL_LIBDIR=lib \
+    -DCMAKE_INSTALL_PREFIX=/usr \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DD_DSG_APP_DATA_FALLBACK=/var/dsg/appdata \
+    -DBUILD_WITH_SYSTEMD=ON \
+    -DDTK_VERSION=$version
   ninja
 }
 


### PR DESCRIPTION
Should extract correct tag version from pkgver and then pass to cmake.
 * extract tag version and pass to cmake
 * format PKGBUILD for fewer changes in the future
 * provide a more sensible default pkgver

Log: fix incorrect version passed to cmake in archlinux build