### PR TITLE
dconfig isdefaultvalue

### DIFF
--- a/docs/global/dconfig.zh_CN.dox
+++ b/docs/global/dconfig.zh_CN.dox
@@ -69,6 +69,14 @@
 @sa DBusBackend::name()
 @sa QSettingBackend::name()
 
+@fn bool Dtk::Core::DConfigBackend::isDefaultValue(const QString &key)
+@brief 检测指定配置项名称对应的值是否为默认值。
+@param[in] key 配置项名称
+@sa DConfig::isDefaultValue()
+@sa FileBackend::isDefaultValue()
+@sa DBusBackend::isDefaultValue()
+@sa QSettingBackend::isDefaultValue()
+
 @class Dtk::Core::QSettingBackend dconfig.h
 @brief QSetting后端,继承自DConfigBackend抽象接口,并实现了虚函数。
 @sa DConfigBackend
@@ -347,6 +355,10 @@ sudo make install
 
 @fn bool Dtk::Core::DConfig::isValid()
 @brief 判断此后端是否可用
+
+@fn bool Dtk::Core::DConfig::isDefaultValue(const QString &key)
+@brief 检测指定配置项名称对应的值是否为默认值。
+@param[in] key 配置项名称
 
 @fn QVariant Dtk::Core::DConfig::value(const QString &key, const QVariant &fallback)
 @brief 根据配置项名称获得对应值

--- a/include/global/dconfig.h
+++ b/include/global/dconfig.h
@@ -22,6 +22,7 @@ public:
     virtual void setValue(const QString &/*key*/, const QVariant &/*value*/) = 0;
     virtual void reset(const QString &key) { setValue(key, QVariant());}
     virtual QString name() const {return QString("");}
+    virtual bool isDefaultValue(const QString &/*key*/) const { return true; }
 };
 
 class DConfigPrivate;
@@ -53,6 +54,7 @@ public:
     QStringList keyList() const;
 
     bool isValid() const;
+    bool isDefaultValue(const QString &key) const;
     QVariant value(const QString &key, const QVariant &fallback = QVariant()) const;
     void setValue(const QString &key, const QVariant &value);
     void reset(const QString &key);

--- a/src/dbus/org.desktopspec.ConfigManager.Manager.xml
+++ b/src/dbus/org.desktopspec.ConfigManager.Manager.xml
@@ -13,6 +13,10 @@ SPDX-License-Identifier: LGPL-3.0-or-later
       <arg type='s' name='key' direction='in'/>
       <arg type='v' name='value' direction='out'/>
     </method>
+    <method name='isDefaultValue'>
+      <arg type='s' name='key' direction='in'/>
+      <arg type='b' name='isDefaultValue' direction='out'/>
+    </method>
     <method name='setValue'>
       <arg type='s' name='key' direction='in'/>
       <arg type='v' name='value' direction='in'/>

--- a/src/dconfig.cpp
+++ b/src/dconfig.cpp
@@ -212,8 +212,7 @@ public:
 
     virtual void reset(const QString &key) override
     {
-        const auto &originValue = configFile->meta()->value(key);
-        setValue(key, originValue);
+        setValue(key, QVariant());
     }
 
     virtual QString name() const override

--- a/src/dconfig.cpp
+++ b/src/dconfig.cpp
@@ -88,6 +88,12 @@ static QString NoAppId;
 
     @brief The unique identity of the backend configuration
 
+/*!
+@~english
+ @fn bool DConfigBackend::isDefaultValue(const QString &key) const = 0
+
+ @sa DConfig::isDefaultValue()
+
  */
 
 DConfigBackend::~DConfigBackend()
@@ -200,6 +206,13 @@ public:
         // fallback to default value of generic configuration.
         const QVariant &vg = genericConfigFile->value(key);
         return vg.isValid() ? vg : fallback;
+    }
+
+    virtual bool isDefaultValue(const QString &key) const override
+    {
+        // Don't fallback to generic configuration
+        const QVariant &vc = configFile->cacheValue(configCache.get(), key);
+        return !vc.isValid();
     }
 
     virtual void setValue(const QString &key, const QVariant &value) override
@@ -377,6 +390,17 @@ public:
             return fallback;
         }
         return decodeQDBusArgument(reply.value().variant());
+    }
+
+    virtual bool isDefaultValue(const QString &key) const override
+    {
+        auto reply = config->isDefaultValue(key);
+        reply.waitForFinished();
+        if (reply.isError()) {
+            qWarning() << "value error key:" << key << ", error message:" << reply.error().message();
+            return true;
+        }
+        return reply.value();
     }
 
     virtual void setValue(const QString &key, const QVariant &value) override
@@ -687,6 +711,20 @@ bool DConfig::isValid() const
 {
     D_DC(DConfig);
     return !d->invalid();
+}
+
+/*!
+@~english
+ * @brief Check whether the value is default according to the configuration item name
+ * @param key Configuration Item Name
+ * @return Return `true` if the value isn't been set, otherwise return `false`
+ */
+bool DConfig::isDefaultValue(const QString &key) const
+{
+    D_DC(DConfig);
+    if (d->invalid())
+        return false;
+    return d->backend->isDefaultValue(key);
 }
 
 /*!

--- a/tests/ut_dconfig.cpp
+++ b/tests/ut_dconfig.cpp
@@ -206,3 +206,23 @@ TEST_F(ut_DConfig, DSettingsDConfigBackend)
         ASSERT_EQ(backend.getOption("key2").toString(), QString("126"));
     }
 }
+
+TEST_F(ut_DConfig, isDefaultValue) {
+
+    FileCopyGuard guard(":/data/dconf-example.meta.json", metaFilePath);
+    {
+        DConfig config(FILE_NAME);
+        ASSERT_EQ(config.isDefaultValue("key2"), true);
+    }
+    {
+        DConfig config(FILE_NAME);
+        config.setValue("key2", "126");
+        EXPECT_EQ(config.isDefaultValue("key2"), false);
+    }
+    {
+        DConfig config(FILE_NAME);
+        config.setValue("key2", "126");
+        config.reset("key2");
+        EXPECT_EQ(config.isDefaultValue("key2"), true);
+    }
+}


### PR DESCRIPTION
- fix: Don't clear cache when reset for DConfig in FileBackend
- feat: Add isDefaultValue for DConfig
