### PR TITLE
fix: missing parameter passing for synchronization

### DIFF
--- a/.github/workflows/call-synchronize-to-dtk6.yml
+++ b/.github/workflows/call-synchronize-to-dtk6.yml
@@ -14,5 +14,6 @@ jobs:
     secrets: inherit
     with:
       dest_repo: linuxdeepin/dtk6core
+      source_repo: ${{ github.event.pull_request.head.repo.full_name }}
       source_ref: ${{ github.event.pull_request.head.ref }}
       pull_number: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
Synchronize-to-dtk6 parameter passing has changed. Synchronize the
new usage.

Log: synchronize new form of parameter passing for synchronize-to-dtk6
Related-to: https://github.com/linuxdeepin/dtk/pull/129
