### PR TITLE
fix: Compiling failed in libspdlog-dev before 1.4.0

### DIFF
--- a/src/log/rollingfilesink_p.h
+++ b/src/log/rollingfilesink_p.h
@@ -36,7 +36,11 @@ struct rolling_filename_calculator
     static filename_t calc_filename(const filename_t &filename, const tm &now_tm)
     {
 #if SPDLOG_VERSION < SPDLOG_VERSION_CHECK(1,10,0)
+    #if SPDLOG_VERSION < SPDLOG_VERSION_CHECK(1,4,0)
+        std::conditional<std::is_same<filename_t::value_type, char>::value, fmt::basic_memory_buffer<char, 250>, fmt::basic_string_view<wchar_t>>::type w;
+    #else
         std::conditional<std::is_same<filename_t::value_type, char>::value, spdlog::memory_buf_t, spdlog::wmemory_buf_t>::type w;
+    #endif
         fmt::format_to(w, SPDLOG_FILENAME_T("{}.{:04d}-{:02d}-{:02d}-{:02d}-{:02d}-{:02d}"), filename,
                        now_tm.tm_year + 1900, now_tm.tm_mon + 1, now_tm.tm_mday,
                        now_tm.tm_hour, now_tm.tm_min, now_tm.tm_sec);


### PR DESCRIPTION
spdlog::memory_but_t and spdlog::wmemory_but_t are introduced after 1.4.0.

UOS 1060 ships with libspdlog-dev 1.3.1, this fix solved the compiling failed in UOS.