### PR TITLE
chore: fix relative path invalid link

### DIFF
--- a/tools/dci/main.cpp
+++ b/tools/dci/main.cpp
@@ -125,7 +125,7 @@ bool exportTo(const QString &dciFile, const QString &targetDir) {
         return false;
 
     QMap<QString, QString> pathMap;
-    if (!copyFilesFromDci(&dci, newDir, "/", pathMap))
+    if (!copyFilesFromDci(&dci, QDir(newDir).absolutePath(), "/", pathMap))
         return false;
 
     // link to real source


### PR DESCRIPTION
```
 dci --export ./ ./xxx.dci
 # invalid symlink ./1.webp -> 3/36/normal.light/3/1.webp
```
应该是 ./1.webp ->  ../../normal.light/3/1.webp