### PR TITLE
fix: DConfig add check for name

### DIFF
--- a/src/dconfigfile.cpp
+++ b/src/dconfigfile.cpp
@@ -45,6 +45,13 @@ inline static bool subpathIsValid(const QString &subpath, const QDir &dir)
     const QDir subDir(dir.filePath(subpath.mid(1)));
     return subDir.absolutePath().startsWith(dir.absolutePath());
 }
+// name must be a valid filename.
+inline static bool isValidFilename(const QString& filename)
+{
+    static const QRegularExpression regex("^[\\w\\-\\.\\ ]+$");
+    QRegularExpressionMatch match = regex.match(filename);
+    return match.hasMatch();
+}
 /*!
 @~english
   \internal
@@ -682,6 +689,10 @@ public:
 
     bool load(const QString &localPrefix) override
     {
+        if (!isValidFilename(configKey.fileName)) {
+            qCWarning(cfLog, "Name is invalid, filename=%s", qPrintable(configKey.fileName));
+            return false;
+        }
         bool useAppIdForOverride = true;
         QString path = metaPath(localPrefix, &useAppIdForOverride);
         if (path.isEmpty()) {

--- a/tests/ut_dconfigfile.cpp
+++ b/tests/ut_dconfigfile.cpp
@@ -496,3 +496,24 @@ TEST_F(ut_DConfigFile, userPublic) {
         ASSERT_FALSE(config.meta()->flags("canExit").testFlag(DConfigFile::UserPublic));
     }
 }
+
+class ut_DConfigFileCheckName : public ut_DConfigFile, public ::testing::WithParamInterface<std::tuple<QString, bool>>
+{
+
+};
+
+TEST_P(ut_DConfigFileCheckName, checkName)
+{
+    const auto [fileName, isValid] = GetParam();
+    FileCopyGuard guard(":/data/dconf-example.meta.json", QString("%1/%2.json").arg(metaPath, fileName));
+    DConfigFile config(APP_ID, fileName);
+    ASSERT_EQ(config.load(LocalPrefix), isValid);
+}
+INSTANTIATE_TEST_SUITE_P(checkName, ut_DConfigFileCheckName,
+                         ::testing::Values(
+                             std::tuple{QString("org-foo"), true},
+                             std::tuple{QString("org foo"), true},
+                             std::tuple{QString("org.foo2"), true},
+                             std::tuple{QString("org/foo"), false},
+                             std::tuple{QString("./org-foo"), false},
+                             std::tuple{QString("../configs/org-foo"), false}));


### PR DESCRIPTION
  user can open non-root controlled files when `name` is relative path.

Issue: https://bugzilla.suse.com/show_bug.cgi?id=1211374
