### PR TITLE
feat: support to set appId for DConfig

### DIFF
--- a/docs/global/dconfig.zh_CN.dox
+++ b/docs/global/dconfig.zh_CN.dox
@@ -344,6 +344,11 @@ sudo make install
 @param[in] parent 父对象
 @note 调用者只构造backend,由DConfig释放。
 
+@fn static void DConfig::setAppId(const QString &appId)
+@brief 显示指定应用Id,不采用DSGApplication::id()作为应用Id
+@param[in] appId 配置文件所属的应用Id
+@note 需要在QCoreApplication构造前设置。
+
 @fn QString Dtk::Core::DConfig::backendName()
 @brief 配置策略后端名称
 @return 配置策略后端名称

--- a/include/global/dconfig.h
+++ b/include/global/dconfig.h
@@ -49,6 +49,8 @@ public:
     static DConfig *createGeneric(DConfigBackend *backend, const QString &name, const QString &subpath = QString(),
                                   QObject *parent = nullptr);
 
+    static void setAppId(const QString &appId);
+
     QString backendName() const;
 
     QStringList keyList() const;

--- a/src/dconfig.cpp
+++ b/src/dconfig.cpp
@@ -100,6 +100,7 @@ DConfigBackend::~DConfigBackend()
 {
 }
 
+static QString _globalAppId;
 class Q_DECL_HIDDEN DConfigPrivate : public DObjectPrivate
 {
 public:
@@ -600,7 +601,7 @@ DConfig::DConfig(const QString &name, const QString &subpath, QObject *parent)
 }
 
 DConfig::DConfig(DConfigBackend *backend, const QString &name, const QString &subpath, QObject *parent)
-    : DConfig(backend, DSGApplication::id(), name, subpath, parent)
+    : DConfig(backend, _globalAppId.isEmpty() ? DSGApplication::id() : _globalAppId, name, subpath, parent)
 {
 
 }
@@ -643,6 +644,20 @@ DConfig *DConfig::createGeneric(const QString &name, const QString &subpath, QOb
 DConfig *DConfig::createGeneric(DConfigBackend *backend, const QString &name, const QString &subpath, QObject *parent)
 {
     return new DConfig(backend, NoAppId, name, subpath, parent);
+}
+
+/*!
+ * \brief Explicitly specify application Id for config.
+ * \param appId
+ * @note It's should be called before QCoreApplication constructed.
+ */
+void DConfig::setAppId(const QString &appId)
+{
+    if (!_globalAppId.isEmpty()) {
+        qCWarning(cfLog, "`setAppId`should only be called once.");
+    }
+    _globalAppId = appId;
+    qCDebug(cfLog, "Explicitly specify application Id as appId=%s for config.", qPrintable(appId));
 }
 
 /*!


### PR DESCRIPTION
  It's useful for generic config to clearly specify application id.
