### PR TITLE
fix: fix undefined reference errors on spdlog 1.14.0

### DIFF
--- a/src/log/ConsoleAppender.cpp
+++ b/src/log/ConsoleAppender.cpp
@@ -7,6 +7,9 @@
 #include "ConsoleAppender.h"
 
 #include <spdlog/spdlog.h>
+#include <spdlog/spdlog-inl.h>
+#include <spdlog/details/registry.h>
+#include <spdlog/details/registry-inl.h>
 #include <spdlog/sinks/stdout_color_sinks.h>
 
 // STL


### PR DESCRIPTION
Support spdlog 1.14.0

Log: spdlog 1.14.0 added string view overloads for logger accessor. We should include more headers for this change in dtkcore.