### PR TITLE
Loggingrules dconfig support (cherry-pick from gerrit)

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -8,9 +8,15 @@ DEB_HOST_MULTIARCH ?= $(shell dpkg-architecture -qDEB_HOST_MULTIARCH)
 
 VERSION = $(DEB_VERSION_UPSTREAM)
 PACK_VER = $(shell echo $(VERSION) | awk -F'[+_~-]' '{print $$1}')
-# Fix: invalid digit "8" in octal constant. e.g.  u008 ==> 008 ==> 8
-BUILD_VER = $(shell echo $(VERSION) | awk -F'[+_~-]' '{print $$2}' | sed 's/[^0-9]//g' | awk '{print int($$1)}')
 
+# Calculate build version:
+# 5.6.8 -> 0; 5.6.8.7 -> 7; 5.6.8+u001 -> 1; 5.6.8.7+u001 -> 7; 5.6.8.0+u001 -> 0
+BUILD_VER = $(shell echo $(VERSION) | awk -F'[+_~-]' '{print $$1}' | awk -F'.' '{print $$4}' | sed 's/[^0-9]//g' | awk '{print int($$1)}')
+ifeq ($(BUILD_VER), 0)
+ifeq ($(shell expr $(shell echo "$(VERSION)" | awk -F. '{print NF-1}') '<' 3), 1)
+	BUILD_VER=$(shell echo $(VERSION) | awk -F'[+_~-]' '{print $$2}'  | sed 's/[^0-9]//g' | awk '{print int($$1)}')
+endif
+endif
 
 %:
 	dh $@

--- a/include/global/dsysinfo.h
+++ b/include/global/dsysinfo.h
@@ -38,7 +38,8 @@ public:
         DeepinDesktop,
         DeepinProfessional,
         DeepinServer,
-        DeepinPersonal
+        DeepinPersonal,
+        DeepinMilitary
     };
 
     enum LogoType {

--- a/include/log/LogManager.h
+++ b/include/log/LogManager.h
@@ -31,10 +31,18 @@ public:
 
     static void setLogFormat(const QString &format);
 
+    /*!
+     * \brief 监听 org.deepin.dtk.log 的变化动态调整应用的日志输出规则
+     * 此方法应该在创建 QApplication 之前调用，否则 QT_LOGGING_RULES 环境变量会覆盖 dconfig 的的值
+     * \a logFilePath 指定 dconfig 的 appId
+     */
+    static void registerLoggingRulesWatcher(const QString &appId);
+
 private:
     void initConsoleAppender();
     void initRollingFileAppender();
     void initJournalAppender();
+    void initLoggingRules(const QString &appId);
     QString joinPath(const QString &path, const QString &fileName);
 
     inline static DLogManager* instance(){

--- a/include/log/LogManager.h
+++ b/include/log/LogManager.h
@@ -31,18 +31,10 @@ public:
 
     static void setLogFormat(const QString &format);
 
-    /*!
-     * \brief 监听 org.deepin.dtk.log 的变化动态调整应用的日志输出规则
-     * 此方法应该在创建 QApplication 之前调用，否则 QT_LOGGING_RULES 环境变量会覆盖 dconfig 的的值
-     * \a logFilePath 指定 dconfig 的 appId
-     */
-    static void registerLoggingRulesWatcher(const QString &appId);
-
 private:
     void initConsoleAppender();
     void initRollingFileAppender();
     void initJournalAppender();
-    void initLoggingRules(const QString &appId);
     QString joinPath(const QString &path, const QString &fileName);
 
     inline static DLogManager* instance(){

--- a/src/dsysinfo.cpp
+++ b/src/dsysinfo.cpp
@@ -227,6 +227,8 @@ void DSysInfoPrivate::ensureDeepinInfo()
         deepinType = DSysInfo::DeepinServer;
     } else if (deepin_type == "Personal") {
         deepinType = DSysInfo::DeepinPersonal;
+    } else if (deepin_type == "Military") {
+        deepinType = DSysInfo::DeepinMilitary;
     } else {
         deepinType = DSysInfo::UnknownDeepin;
     }

--- a/src/dsysinfo.cpp
+++ b/src/dsysinfo.cpp
@@ -157,7 +157,7 @@ bool DSysInfoPrivate::splitA_BC_DMode()
 
 void DSysInfoPrivate::ensureDeepinInfo()
 {
-    if (static_cast<int>(deepinType) >= 0 && !inTest())
+    if (static_cast<int>(deepinType) > 0 && !inTest())
         return;
 
     if (inTest())
@@ -430,7 +430,7 @@ static bool readLsbRelease(DSysInfoPrivate *info)
 
 void DSysInfoPrivate::ensureReleaseInfo()
 {
-    if (productType >= 0 && !inTest()) {
+    if (productType > 0 && !inTest()) {
         return;
     }
 

--- a/src/dsysinfo.cpp
+++ b/src/dsysinfo.cpp
@@ -17,6 +17,7 @@
 #include <QStandardPaths>
 #include <QDateTime>
 #include <QRegularExpression>
+#include <QLoggingCategory>
 #include <qmath.h>
 
 #ifdef Q_OS_LINUX
@@ -36,6 +37,12 @@ static inline bool inTest()
 }
 
 DCORE_BEGIN_NAMESPACE
+
+#ifdef QT_DEBUG
+Q_LOGGING_CATEGORY(logSysInfo, "dtk.dsysinfo")
+#else
+Q_LOGGING_CATEGORY(logSysInfo, "dtk.dsysinfo", QtInfoMsg)
+#endif
 
 class Q_DECL_HIDDEN DSysInfoPrivate
 {
@@ -1122,18 +1129,35 @@ qint64 DSysInfo::memoryInstalledSize()
         }
 
         const QByteArray &lshwInfoJson = lshw.readAllStandardOutput();
-        QJsonArray lshwResultArray = QJsonDocument::fromJson(lshwInfoJson).array();
-        if (!lshwResultArray.isEmpty()) {
-            QJsonValue memoryHwInfo = lshwResultArray.first();
-            QString id = memoryHwInfo.toObject().value("id").toString();
-            Q_ASSERT(id == "memory");
-            siGlobal->memoryInstalledSize = memoryHwInfo.toObject().value("size").toDouble(); // TODO: check "units" is "bytes" ?
+
+        QJsonParseError error;
+        auto doc = QJsonDocument::fromJson(lshwInfoJson, &error);
+        if (error.error != QJsonParseError::NoError) {
+            qCWarning(logSysInfo(), "parse failed, expect json doc from lshw command");
+            return -1;
+        }
+
+        if (!doc.isArray()) {
+            qCWarning(logSysInfo(), "parse failed, expect array");
+            return -1;
+        }
+
+        QJsonArray lshwResultArray = doc.array();
+        for (const QJsonValue value : lshwResultArray) {
+            QJsonObject obj = value.toObject();
+            if (obj.contains("id") && obj.value("id").toString() == "memory") {
+                siGlobal->memoryInstalledSize = obj.value("size").toDouble(); // TODO: check "units" is "bytes" ?
+                break;
+            }
         }
     }
 
+    Q_ASSERT(siGlobal->memoryInstalledSize > 0);
+
     return siGlobal->memoryInstalledSize;
-#endif
+#else
     return -1;
+#endif
 }
 
 /*!

--- a/src/log/AbstractStringAppender.cpp
+++ b/src/log/AbstractStringAppender.cpp
@@ -339,6 +339,11 @@ QString AbstractStringAppender::formattedString(const QDateTime &time, Logger::L
                                                 bool withcolor) const
 {
     QString f = format();
+
+    // dtkcore无法正确解析Qt的日志格式，dtk默认的日志格式并未和Qt统一，解析方式需要兼容两种不同的格式。
+    if (f.contains(QLatin1String("time ")))
+        f.replace(f.indexOf(' ', f.indexOf(QLatin1String("time")) + QLatin1String("time").size()), 1, QLatin1String("}{"));
+
     const int size = f.size();
 
     QString result;

--- a/src/log/ConsoleAppender.cpp
+++ b/src/log/ConsoleAppender.cpp
@@ -38,7 +38,7 @@ DCORE_BEGIN_NAMESPACE
 
 ConsoleAppender::ConsoleAppender()
     : AbstractStringAppender()
-    ,m_ignoreEnvPattern(false)
+    , m_ignoreEnvPattern(false)
 {
     if (!spdlog::get("console")) {
         auto clogger = spdlog::stdout_color_mt("console");

--- a/src/log/LogManager.cpp
+++ b/src/log/LogManager.cpp
@@ -133,18 +133,8 @@ void DLogManager::initLoggingRules(const QString &appId)
         return;
     }
 
-    // QT_LOGGING_RULES环境变量设置日志的优先级最高
-    // QLoggingRegistry 初始化时会获取 QT_LOGGING_RULES 的值并保存，后续重置了环境变量 QLoggingRegistry 不会进行同步
-    // 需要在 QLoggingRegistry 初始化之前重置 QT_LOGGING_RULES 的值
-    QByteArray logRules = qgetenv("QT_LOGGING_RULES");
-    qunsetenv("QT_LOGGING_RULES");
-
-    if (!logRules.isEmpty()) {
-        QLoggingCategory::setFilterRules(logRules.replace(";", "\n"));
-    }
-
     Q_D(DLogManager);
-    d->m_loggingRulesConfig = DConfig::create(appId, "org.deepin.dtk.loggingrules");
+    d->m_loggingRulesConfig = DConfig::create(appId, "org.deepin.dtk.preference");
     if (!d->m_loggingRulesConfig) {
         qWarning() << "Create logging rules dconfig object failed, logging rules won't take effect";
         return;
@@ -155,6 +145,16 @@ void DLogManager::initLoggingRules(const QString &appId)
         delete d->m_loggingRulesConfig;
         d->m_loggingRulesConfig = nullptr;
         return;
+    }
+
+    // QT_LOGGING_RULES环境变量设置日志的优先级最高
+    // QLoggingRegistry 初始化时会获取 QT_LOGGING_RULES 的值并保存，后续重置了环境变量 QLoggingRegistry 不会进行同步
+    // 需要在 QLoggingRegistry 初始化之前重置 QT_LOGGING_RULES 的值
+    QByteArray logRules = qgetenv("QT_LOGGING_RULES");
+    qunsetenv("QT_LOGGING_RULES");
+
+    if (!logRules.isEmpty()) {
+        QLoggingCategory::setFilterRules(logRules.replace(";", "\n"));
     }
 
     auto updateLoggingRules = [d](const QString & key) {


### PR DESCRIPTION
-  允许基于dtk开发的应用动态控制其日志输出等级 
-  lshw查询内存大小时返回多元素数组,修正解析过程
- 从文件中读取deepinType和productType值时因为权限问题会失败
- 增加registerLoggingRulesWatcher接口
- 修复计算 build 版本号错误的问题 
- 修复日志格式时间戳显示异常问题

https://github.com/linuxdeepin/dtkcommon/pull/70
