### PR TITLE
fix: DConfigFile is invalid when AppId is empty

### DIFF
--- a/src/dconfigfile.cpp
+++ b/src/dconfigfile.cpp
@@ -52,11 +52,12 @@ inline static bool isValidFilename(const QString& filename)
     QRegularExpressionMatch match = regex.match(filename);
     return match.hasMatch();
 }
+// AppId don't contain ' ', but it can be empty.
 inline static bool isValidAppId(const QString& appId)
 {
-    if (appId.contains(' '))
-        return false;
-    return isValidFilename(appId);
+    static const QRegularExpression regex("^[\\w\\-\\.]*$");
+    QRegularExpressionMatch match = regex.match(appId);
+    return match.hasMatch();
 }
 /*!
 @~english

--- a/tests/ut_dconfigfile.cpp
+++ b/tests/ut_dconfigfile.cpp
@@ -532,6 +532,7 @@ TEST_P(ut_DConfigFileCheckAppId, checkAppId)
 }
 INSTANTIATE_TEST_SUITE_P(checkAppId, ut_DConfigFileCheckAppId,
                          ::testing::Values(
+                             std::tuple{NoAppId, true},
                              std::tuple{QString("org-foo"), true},
                              std::tuple{QString("org foo"), false},
                              std::tuple{QString("org.foo2"), true},


### PR DESCRIPTION
Empty is used in dde-dconfig-daemon, and it is valid.
