### PR TITLE
refactor: remove LoggingRules interface

### DIFF
--- a/include/global/dconfig.h
+++ b/include/global/dconfig.h
@@ -22,6 +22,7 @@ public:
     virtual void setValue(const QString &/*key*/, const QVariant &/*value*/) = 0;
     virtual void reset(const QString &key) { setValue(key, QVariant());}
     virtual QString name() const {return QString("");}
+    virtual bool isDefaultValue(const QString &/*key*/) const { return true; }
 };
 
 class DConfigPrivate;
@@ -53,6 +54,7 @@ public:
     QStringList keyList() const;
 
     bool isValid() const;
+    bool isDefaultValue(const QString &key) const;
     QVariant value(const QString &key, const QVariant &fallback = QVariant()) const;
     void setValue(const QString &key, const QVariant &value);
     void reset(const QString &key);

--- a/include/log/LogManager.h
+++ b/include/log/LogManager.h
@@ -6,20 +6,16 @@
 #ifndef LOGMANAGER_H
 #define LOGMANAGER_H
 
-#include <QtCore>
+#include <QScopedPointer>
 
 #include "dtkcore_global.h"
 
 DCORE_BEGIN_NAMESPACE
 
-class ConsoleAppender;
-class RollingFileAppender;
-class JournalAppender;
-
-class DConfig;
-
+class DLogManagerPrivate;
 class LIBDTKCORESHARED_EXPORT DLogManager
 {
+    Q_DISABLE_COPY(DLogManager)
 public:
     static void registerConsoleAppender();
     static void registerFileAppender();
@@ -35,26 +31,13 @@ public:
 
     static void setLogFormat(const QString &format);
 
-    /*!
-     * \brief 监听 org.deepin.dtk.log 的变化动态调整应用的日志输出规则
-     * 此方法应该在创建 QApplication 之前调用，否则 QT_LOGGING_RULES 环境变量会覆盖 dconfig 的的值
-     * \a logFilePath 指定 dconfig 的 appId
-     */
+    // 废弃接口，现已改为默认启用(可以用 DTK_DISABLED_LOGGING_RULES 禁用)
     static void registerLoggingRulesWatcher(const QString &appId);
 
 private:
-//TODO: move it to private class (DTK6)
-    QString m_format;
-    QString m_logPath;
-    ConsoleAppender* m_consoleAppender;
-    RollingFileAppender* m_rollingFileAppender;
-    JournalAppender* m_journalAppender;
-    DConfig* m_loggingRulesConfig;
-
     void initConsoleAppender();
     void initRollingFileAppender();
     void initJournalAppender();
-    void initLoggingRules(const QString &appId);
     QString joinPath(const QString &path, const QString &fileName);
 
     inline static DLogManager* instance(){
@@ -63,8 +46,9 @@ private:
     }
     explicit DLogManager();
     ~DLogManager();
-    DLogManager(const DLogManager &);
-    DLogManager & operator = (const DLogManager &);
+
+    QScopedPointer<DLogManagerPrivate> d_ptr;
+    Q_DECLARE_PRIVATE(DLogManager)
 };
 
 DCORE_END_NAMESPACE

--- a/src/dbus/org.desktopspec.ConfigManager.Manager.xml
+++ b/src/dbus/org.desktopspec.ConfigManager.Manager.xml
@@ -13,6 +13,10 @@ SPDX-License-Identifier: LGPL-3.0-or-later
       <arg type='s' name='key' direction='in'/>
       <arg type='v' name='value' direction='out'/>
     </method>
+    <method name='isDefaultValue'>
+      <arg type='s' name='key' direction='in'/>
+      <arg type='b' name='isDefaultValue' direction='out'/>
+    </method>
     <method name='setValue'>
       <arg type='s' name='key' direction='in'/>
       <arg type='v' name='value' direction='in'/>


### PR DESCRIPTION
- 移除相关接口， 默认启用(可以用 DTK_DISABLED_LOGGING_RULES 禁用)
- 优先使用 dsgAppId ， 用户可以通过 DTK_LOGGING_FALLBACK_APPID 指定 fallbackAppId
- 有配置过 rules 时， 优先使用（即非默认值优先）
- fallbackConfig 发生变化时会检查 dsgConfig 是否修改过，是则忽略