### PR TITLE
chore: bump version to 5.6.31

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dtkcore (5.6.31) unstable; urgency=medium
+
+  * chore: use '&&' and '||' instead of 'and' and 'or'
+
+ -- zsien <quezhiyong@deepin.org>  Mon, 17 Jun 2024 13:11:06 +0800
+
 dtkcore (5.6.30) unstable; urgency=medium
 
   * feat: 允许基于dtk开发的应用动态控制其日志输出等级(Task: 307567)(Influence: 允许基于dtk开发的应用动态控制其日志输出等级)


### PR DESCRIPTION
  * chore: use '&&' and '||' instead of 'and' and 'or'