### PR TITLE
fix: remove unnecessary link libraries

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -67,9 +67,7 @@ if(LINUX)
     Dtk${DTK_VERSION_MAJOR}::Log
   )
   target_link_libraries(${LIB_NAME} PRIVATE
-    ICU::uc
     Qt${QT_VERSION_MAJOR}::CorePrivate
-    uchardet
   )
   if("${QT_VERSION_MAJOR}" STREQUAL "5")
     target_link_libraries(${LIB_NAME} PRIVATE
@@ -93,9 +91,7 @@ else()
     Qt${QT_VERSION_MAJOR}::Xml
   )
   target_link_libraries(${LIB_NAME} PRIVATE
-    ICU::uc
     Qt${QT_VERSION_MAJOR}::CorePrivate
-    uchardet
   )
   if("${QT_VERSION_MAJOR}" STREQUAL "5")
     target_link_libraries(${LIB_NAME} PRIVATE


### PR DESCRIPTION
These two libraries are used to detect text encoding, 
but they are actually loaded dynamiclly.
Not need to link libraries.