### PR TITLE
fix(util): error appid from `getAppIdFromAbsolutePath`

### DIFF
--- a/include/util/dutil.h
+++ b/include/util/dutil.h
@@ -96,7 +96,7 @@ inline QString getAppIdFromAbsolutePath(const QString &path)
         return {};
     }
 
-    auto tmp = path.chopped(desktopSuffix.size() - 1);
+    auto tmp = path.chopped(desktopSuffix.size());
     auto components = tmp.split(QDir::separator(), Qt::SkipEmptyParts);
     auto location = std::find(components.cbegin(), components.cend(), "applications");
     if (location == components.cend()) {


### PR DESCRIPTION
Log: tmp变量读出来的字符串多带了一个字符