### PR TITLE
fix(build): debian/rule use tab instead of space

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -22,7 +22,7 @@ endif
 	dh $@
 
 override_dh_auto_configure:
-        dh_auto_configure -- -DBUILD_WITH_SYSTEMD=ON -DBUILD_EXAMPLES=OFF -DBUILD_DOCS=ON -DBUILD_VERSION=$(BUILD_VER) -DDTK_VERSION=$(PACK_VER) -DD_DSG_APP_DATA_FALLBACK=/var/dsg/appdata
+	dh_auto_configure -- -DBUILD_WITH_SYSTEMD=ON -DBUILD_EXAMPLES=OFF -DBUILD_DOCS=ON -DBUILD_VERSION=$(BUILD_VER) -DDTK_VERSION=$(PACK_VER) -DD_DSG_APP_DATA_FALLBACK=/var/dsg/appdata
 
 #override_dh_auto_test:
 #	echo "skip auto test"


### PR DESCRIPTION
space ==> tab