### PR TITLE
fix: hasVtable is incorrect when destructing

### DIFF
--- a/src/util/dvtablehook.cpp
+++ b/src/util/dvtablehook.cpp
@@ -174,15 +174,15 @@ void DVtableHook::autoCleanVtable(const void *obj)
     if (!fun)
         return;
 
-    typedef void(*Destruct)(const void*);
-    Destruct destruct = reinterpret_cast<Destruct>(fun);
-    // call origin destruct function
-    destruct(obj);
-
     if (hasVtable(obj)) {// 需要判断一下，有可能在执行析构函数时虚表已经被删除
         // clean
         clearGhostVtable(obj);
     }
+
+    typedef void(*Destruct)(const void*);
+    Destruct destruct = reinterpret_cast<Destruct>(fun);
+    // call origin destruct function
+    destruct(obj);
 }
 
 bool DVtableHook::ensureVtable(const void *obj, std::function<void ()> destoryObjFun)


### PR DESCRIPTION
Destruct function should be called by 'autoCleanVtable' instead of
'callOriginalFun'.
'glostVtable' should be delete before calling origin destruct,
because 'resetVtable' maybe called when destructing origin destruct.

pms: BUG-368399
