### PR TITLE
fix: double value is converted to int for DConfig

### DIFF
--- a/tests/data/dconf-example.meta.json
+++ b/tests/data/dconf-example.meta.json
@@ -40,6 +40,14 @@
       "permissions": "readwrite",
       "visibility": "public"
     },
+    "numberDouble": {
+      "value": 1.0,
+      "serial": 0,
+      "flags": ["global"],
+      "name": "double value type",
+      "permissions": "readwrite",
+      "visibility": "public"
+    },
     "array": {
       "value": ["value1", "value2"],
       "serial": 0,

--- a/tests/ut_dconfigfile.cpp
+++ b/tests/ut_dconfigfile.cpp
@@ -125,6 +125,11 @@ TEST_F(ut_DConfigFile, setValueTypeCheck) {
         ASSERT_EQ(config.value("number", userCache.get()).type(), type);
     }
     {
+        const auto type = config.value("numberDouble", userCache.get()).type();
+        ASSERT_TRUE(config.setValue("numberDouble", 1.2, "test", userCache.get()));
+        ASSERT_EQ(config.value("numberDouble", userCache.get()), 1.2);
+    }
+    {
         const auto type = config.value("array", userCache.get()).type();
         const QStringList array{"value1", "value2"};
         ASSERT_TRUE(config.setValue("array", QStringList(), "test", userCache.get()));


### PR DESCRIPTION
MetaType of 1.0 is qlonglong instead of double in json file.
We don't convert if source value is double.
