### PR TITLE
fix: resolve compilation failure on Qt 6.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+<a name="5.7.14"></a>
+## 5.7.14 (2025-04-12)
+
+### Bug Fixes
+
+* resolve compilation failure on Qt 6.9
+
 <a name="2.0.14"></a>
 ## 2.0.14 (2019-05-23)
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dtkcore (5.7.14) unstable; urgency=medium
+
+  * fix: resolve compilation failure on Qt 6.9
+
+ -- JiDe Zhang <zhangjide@deepin.org>  Sat, 12 Apr 2025 17:19:00 +0800
+
 dtkcore (5.7.13) unstable; urgency=medium
 
   * fix: add copyright for dconfig_org_deepin_dtk_preference.hpp

--- a/include/util/dvtablehook.h
+++ b/include/util/dvtablehook.h
@@ -222,7 +222,11 @@ public:
         Q_STATIC_ASSERT_X((FunctorArgumentCount >= 0),
                           "Function1 and Function2 arguments are not compatible.");
         const int Fun2ArgumentCount = (FunctorArgumentCount >= 0) ? FunctorArgumentCount : 0;
+#if QT_VERSION >= QT_VERSION_CHECK(6, 9, 0)
+        typedef typename QtPrivate::FunctorReturnType<Fun2, typename QtPrivate::List_Left<typename FunctionPointer<Fun1>::Arguments, Fun2ArgumentCount>::Value>::type Fun2ReturnType;
+#else
         typedef typename QtPrivate::FunctorReturnType<Fun2, typename QtPrivate::List_Left<typename FunctionPointer<Fun1>::Arguments, Fun2ArgumentCount>::Value>::Value Fun2ReturnType;
+#endif
 
         Q_STATIC_ASSERT_X((QtPrivate::AreArgumentsCompatible<Fun2ReturnType, typename FunInfo1::ReturnType>::value),
                           "Function1 and Function2 return type are not compatible.");

--- a/tools/dconfig2cpp/main.cpp
+++ b/tools/dconfig2cpp/main.cpp
@@ -15,7 +15,7 @@
 static QString toUnicodeEscape(const QString& input) {
     QString result;
     for (QChar ch : input) {
-        result += QString("\\u%1").arg(ch.unicode(), 4, 16, QChar('0'));
+        result += QString("\\u%1").arg(static_cast<short>(ch.unicode()), 4, 16, QChar('0'));
     }
     return result;
 }


### PR DESCRIPTION
Updated the dvtablehook.h file to adjust the typedef for Fun2ReturnType based on changes in Qt 6.9 interfaces. Additionally, the main.cpp file now casts the unicode value to short to prevent type issues. These changes are necessary to ensure compatibility with the latest Qt framework and to resolve the build issues that arise from interface modifications.

修复: 解决在Qt 6.9上的编译失败

更新了dvtablehook.h文件，以根据Qt 6.9接口的变化调整Fun2ReturnType的 typedef。此外，main.cpp文件现在将unicode值转换为short，以防止类型问题。
这些更改对于确保与最新Qt框架兼容以及解决接口修改引起的构建问题是必要的。