### PR TITLE
fix: add missing UosMilitary edition type cases

### DIFF
--- a/src/dsysinfo.cpp
+++ b/src/dsysinfo.cpp
@@ -664,6 +664,7 @@ DSysInfo::UosEdition DSysInfo::uosEditionType()
         case 3:
             return UosCommunity;
         case 4:
+        case 9:
             return UosMilitary;
         case 5:
             return UosDeviceEdition;
@@ -681,6 +682,7 @@ DSysInfo::UosEdition DSysInfo::uosEditionType()
         case 3:
             return UosEuler;
         case 4:
+        case 9:
             return UosMilitaryS;
         case 5:
             return UosDeviceEdition;


### PR DESCRIPTION
Added case 9 to return UosMilitary/UosMilitaryS in uosEditionType
function
The change was necessary because the system needs to recognize edition
type 9 as a valid military edition variant
This ensures proper handling of all supported UOS edition types in the
system

fix: 添加缺失的 UosMilitary 版本类型处理

在 uosEditionType 函数中添加了 case 9 返回 UosMilitary/UosMilitaryS 的
处理
此变更是必要的，因为系统需要将类型9识别为有效的军事版本变体
这确保了系统中对所有支持的 UOS 版本类型的正确处理

pms: BUG-316837
