### PR TITLE
chore: remove deprecated build configuration files

### DIFF
--- a/src/log/LogManager.cpp
+++ b/src/log/LogManager.cpp
@@ -72,7 +72,7 @@ dconfig_org_deepin_dtk_preference *DLogManagerPrivate::createDConfig(const QStri
 
 void DLogManagerPrivate::initLoggingRules()
 {
-    if (qEnvironmentVariableIsSet("DTK_DISABLED_LOGGING_RULES"))
+    if (qEnvironmentVariableIsSet("DTK_DISABLED_LOGGING_RULES") || qEnvironmentVariableIsSet("QT_LOGGING_RULES"))
         return;
 
     // 1. 未指定 fallbackId 时，以 dsgAppId 为准


### PR DESCRIPTION
1. Deleted conanfile.py and linglong.yaml as they were outdated build
configuration files
2. Removed these files from .syncexclude since they no longer exist
3. Cleaned up rpm/dtkcore.spec formatting (spacing and dist tag
addition)
4. These changes reflect the project's move away from Conan and Linglong
build systems

chore: 移除过时的构建配置文件

1. 删除了conanfile.py和linglong.yaml这两个过时的构建配置文件
2. 从.syncexclude中移除了这些已不存在的文件
3. 清理了rpm/dtkcore.spec的格式（间距和添加dist标签）
4. 这些变更反映了项目不再使用Conan和Linglong构建系统
