### PR TITLE
fix: improve logging rules environment variable handling

### DIFF
--- a/src/log/LogManager.cpp
+++ b/src/log/LogManager.cpp
@@ -72,7 +72,7 @@ dconfig_org_deepin_dtk_preference *DLogManagerPrivate::createDConfig(const QStri
 
 void DLogManagerPrivate::initLoggingRules()
 {
-    if (qEnvironmentVariableIsSet("DTK_DISABLED_LOGGING_RULES"))
+    if (qEnvironmentVariableIsSet("DTK_DISABLED_LOGGING_RULES") || qEnvironmentVariableIsSet("QT_LOGGING_RULES"))
         return;
 
     // 1. 未指定 fallbackId 时，以 dsgAppId 为准


### PR DESCRIPTION
1. Modified condition to check for both DTK_DISABLED_LOGGING_RULES and
QT_LOGGING_RULES environment variables
2. This change prevents logging rules from being initialized when either
variable is set
3. Ensures better compatibility with Qt's standard logging configuration
system
4. Maintains backward compatibility while adding support for standard Qt
logging control

fix: 改进日志规则环境变量处理

1. 修改条件以同时检查 DTK_DISABLED_LOGGING_RULES 和 QT_LOGGING_RULES 环
境变量
2. 当任一变量设置时，阻止日志规则初始化
3. 确保与 Qt 标准日志配置系统更好的兼容性
4. 在添加对标准 Qt 日志控制支持的同时保持向后兼容
