### PR TITLE
fix: copy cachePrefix in DConfigFile copy constructor

### DIFF
--- a/src/dconfigfile.cpp
+++ b/src/dconfigfile.cpp
@@ -1407,6 +1407,7 @@ DConfigFile::DConfigFile(const DConfigFile &other)
     D_D(DConfigFile);
     auto cache = new DConfigCacheImpl(d->configKey, InvalidUID, true);
     cache->values = other.d_func()->globalCache->values;
+    cache->cachePrefix = other.d_func()->globalCache->cachePrefix;
     d->globalCache = cache;
 }
 


### PR DESCRIPTION
1. Added missing copy of cachePrefix member when copying DConfigFile
objects
2. The cachePrefix was being lost during copy operations which could
lead to incorrect cache behavior
3. This ensures complete and proper copying of all cache-related data

fix: 在 DConfigFile 拷贝构造函数中复制 cachePrefix

1. 添加了对 cachePrefix 成员的拷贝操作，在复制 DConfigFile 对象时该成员
之前被遗漏
2. 之前拷贝操作会丢失 cachePrefix，可能导致缓存行为异常
3. 此修改确保所有缓存相关数据都能被完整正确地拷贝
