### PR TITLE
fix: make version parameter optional in release workflow

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -5,7 +5,7 @@ on:
       version:
         description: 'Release version (e.g., 1.0.0)'
         type: string
-        required: true
+        required: false
       name:
         description: 'The name of the person to release the version'
         type: string

--- a/rpm/dtkcore.spec
+++ b/rpm/dtkcore.spec
@@ -1,6 +1,6 @@
 Name:           dtkcore
-Version: 5.7.17
-Release: 1
+Version:        5.7.17
+Release:        1%{?dist}
 Summary:        Deepin tool kit core modules
 License:        LGPLv3+
 URL:            https://github.com/linuxdeepin/dtkcore


### PR DESCRIPTION
1. Changed version parameter from required to optional in auto-
release.yml
2. Fixed spec file formatting for Version and Release fields
3. Added %{?dist} macro to Release field for better RPM compatibility

The changes make the release workflow more flexible by allowing version-
less releases when needed. The spec file formatting improvements ensure
consistency with RPM packaging standards, while the %{?dist} macro helps
with proper package distribution tagging.

fix: 在发布工作流中使版本参数可选

1. 在 auto-release.yml 中将版本参数从必填改为可选
2. 修复了 spec 文件中 Version 和 Release 字段的格式
3. 在 Release 字段中添加了 %{?dist} 宏以提升 RPM 兼容性

这些改动使得发布工作流在需要时可以更灵活地进行无版本发布。spec 文件的格
式改进确保了与 RPM 打包标准的一致性，而 %{?dist} 宏有助于正确的软件包分
发标记。
