### PR TITLE
fix: use QCoreApplication for application name

### DIFF
--- a/src/log/LogManager.cpp
+++ b/src/log/LogManager.cpp
@@ -213,7 +213,7 @@ QString DLogManager::getlogFilePath()
         if (!QDir(cachePath).exists()) {
             QDir(cachePath).mkpath(cachePath);
         }
-        instance()->d_func()->m_logPath = instance()->joinPath(cachePath, QString("%1.log").arg(qApp->applicationName()));
+        instance()->d_func()->m_logPath = instance()->joinPath(cachePath, QString("%1.log").arg(QCoreApplication::applicationName()));
     }
 
     return QDir::toNativeSeparators(DLogManager::instance()->d_func()->m_logPath);


### PR DESCRIPTION
Changed from using qApp->applicationName() to
QCoreApplication::applicationName() for getting the application name.
This provides better consistency and reliability as QCoreApplication is
the base class and ensures the method is always available, while qApp
macro might not be defined in all contexts. The change maintains the
same functionality but with more robust implementation.

fix: 使用 QCoreApplication 获取应用名称

将 qApp->applicationName() 改为 QCoreApplication::applicationName() 来获
取应用名称。这提供了更好的一致性和可靠性，因为 QCoreApplication 是基类并
确保方法始终可用，而 qApp 宏在某些上下文中可能未定义。此更改保持了相同的
功能但实现了更健壮的实现。
