### PR TITLE
fix: resolve non-reproducible DBUS code generation issue

### DIFF
--- a/tools/qdbusxml2cpp/qdbusxml2cpp.cpp
+++ b/tools/qdbusxml2cpp/qdbusxml2cpp.cpp
@@ -598,7 +598,7 @@ static void writeProxy(const QString &filename, const QDBusIntrospection::Interf
                << endl;
     }
 
-    QSet<QString> annotations;
+    QStringList annotations;
     for (const QDBusIntrospection::Interface *interface : interfaces) {
         for (const auto &method : interface->methods) {
             for (int i(0); i != method.outputArgs.size(); ++i) {
@@ -638,6 +638,7 @@ static void writeProxy(const QString &filename, const QDBusIntrospection::Interf
         }
     }
 
+    annotations.removeDuplicates();
     if (!skipIncludeAnnotations) {
         for (const QString &annotation : annotations) {
             if (annotation.indexOf('<') == -1) {


### PR DESCRIPTION
Changed QSet to QStringList for annotations collection to ensure
deterministic output order
Added removeDuplicates() call to maintain uniqueness while preserving
order
This fixes non-reproducible builds caused by QSet's unpredictable
iteration order

Log: Fixed DBUS code generation reproducibility issue

Influence:
1. Verify DBUS interface code generation produces identical output for
same inputs
2. Test with multiple interface definitions containing annotations
3. Check build reproducibility across different systems

fix: 修复DBUS代码生成不可重复的问题

将注解集合从QSet改为QStringList以确保输出顺序确定性
添加removeDuplicates()调用在保持顺序的同时确保唯一性
修复了由于QSet迭代顺序不可预测导致的构建不可重复问题

Log: 修复了DBUS代码生成不可重复的问题

Influence:
1. 验证相同输入下DBUS接口代码生成是否产生相同输出
2. 测试包含多个注解的接口定义
3. 检查不同系统间的构建可重复性