### PR TITLE
feat: add deprecation ignore support for DTK

### DIFF
--- a/include/global/dtkcore_global.h
+++ b/include/global/dtkcore_global.h
@@ -35,9 +35,11 @@
 
 #if defined(DTK_STATIC_LIB)
 #  define LIBDTKCORESHARED_EXPORT
+#  define D_IGNORE_DEPRECATIONS
 #else
 #if defined(LIBDTKCORE_LIBRARY)
 #  define LIBDTKCORESHARED_EXPORT Q_DECL_EXPORT
+#  define D_IGNORE_DEPRECATIONS
 #else
 #  define LIBDTKCORESHARED_EXPORT Q_DECL_IMPORT
 #endif
@@ -46,6 +48,10 @@
 #ifdef D_DEPRECATED_CHECK
 #define D_DECL_DEPRECATED_X(text) Q_DECL_HIDDEN
 #define D_DECL_DEPRECATED Q_DECL_HIDDEN
+#else
+#if defined(D_IGNORE_DEPRECATIONS)
+#define D_DECL_DEPRECATED
+#define D_DECL_DEPRECATED_X(text)
 #else
 #ifdef __GNUC__
 #if __GNUC__ < 13
@@ -58,6 +64,7 @@
 #else
 #define D_DECL_DEPRECATED Q_DECL_DEPRECATED
 #define D_DECL_DEPRECATED_X Q_DECL_DEPRECATED_X
+#endif
 #endif
 #endif
 


### PR DESCRIPTION
Added D_IGNORE_DEPRECATIONS macro to suppress deprecation warnings in
DTK core
1. Define D_IGNORE_DEPRECATIONS for static library builds
2. Define D_IGNORE_DEPRECATIONS when building DTK core library
3. Added conditional compilation to skip deprecation attributes when
D_IGNORE_DEPRECATIONS is defined
4. Maintains backward compatibility while allowing projects to ignore
deprecated APIs

This change helps projects transition away from deprecated APIs without
immediate warning noise while maintaining the deprecation markers for
new development

Influence:
1. Test building with D_IGNORE_DEPRECATIONS defined to verify
deprecation warnings are suppressed
2. Test building without D_IGNORE_DEPRECATIONS to ensure deprecation
warnings still appear
3. Verify both static and dynamic library builds work correctly with
this change

feat: 添加DTK废弃接口忽略支持

新增D_IGNORE_DEPRECATIONS宏用于抑制DTK核心中的废弃警告
1. 为静态库构建定义D_IGNORE_DEPRECATIONS
2. 构建DTK核心库时定义D_IGNORE_DEPRECATIONS
3. 添加条件编译，当D_IGNORE_DEPRECATIONS定义时跳过废弃属性
4. 保持向后兼容性同时允许项目忽略废弃API

此变更帮助项目在不立即处理废弃警告的情况下逐步迁移废弃API，同时保留废弃
标记供新开发使用

Influence:
1. 测试定义D_IGNORE_DEPRECATIONS时的构建，验证废弃警告被抑制
2. 测试未定义D_IGNORE_DEPRECATIONS时的构建，确保废弃警告仍然显示
3. 验证静态库和动态库构建在此变更后都能正常工作
