### PR TITLE
fix: add fallback type conversion in demarshall function

### DIFF
--- a/src/util/ddbusinterface.cpp
+++ b/src/util/ddbusinterface.cpp
@@ -43,6 +43,13 @@ static QVariant demarshall(const QMetaProperty &metaProperty, const QVariant &va
     if (value.userType() == qMetaTypeId<QDBusArgument>()) {
         QDBusArgument dbusArg = value.value<QDBusArgument>();
         QDBusMetaType::demarshall(dbusArg, PropType(metaProperty), result.data());
+    } else {
+        auto copy = value;
+        if (copy.convert(PropType(metaProperty))) {
+            result = copy;
+        } else {
+            qDebug() << "Failed to convert value type" << value.typeName() << "to property type" << metaProperty.typeName();
+        }
     }
 
     return result;


### PR DESCRIPTION
- Added else branch to handle non-QDBusArgument values with type conversion
- Improves property value handling when direct DBus unmarshalling is not applicable

Log: add fallback type conversion in demarshall function
pms: BUG-332055