### PR TITLE
fix: replace rmdir with rename for directory operations

### DIFF
--- a/src/filesystem/dtrashmanager_linux.cpp
+++ b/src/filesystem/dtrashmanager_linux.cpp
@@ -123,7 +123,7 @@ static bool renameFile(const QFileInfo &fileInfo, const QString &target, QString
             }
         }
 
-        if (!QDir().rmdir(fileInfo.filePath())) {
+        if (!QDir().rename(fileInfo.filePath(), target)) {
             if (errorString) {
                 *errorString = QString("Cannot remove the %1 dir").arg(fileInfo.filePath());
             }


### PR DESCRIPTION
Changed rmdir to rename when handling directory operations in trash manager
The original code used rmdir to remove directories which could fail if directory is not empty
Using rename operation instead allows moving directories to trash location while preserving contents
This fixes potential data loss when trashing non-empty directories

fix: 将目录操作中的 rmdir 替换为 rename

在回收站管理器中处理目录操作时将 rmdir 改为 rename
原始代码使用 rmdir 删除目录，如果目录不为空则会失败
使用 rename 操作可以将目录移动到回收站位置同时保留内容
这修复了清空非空目录时可能出现的数据丢失问题