### PR TITLE
fix(deepin-os-release): Filter out RDRAND hardware random warnings to ensure clean output

### DIFF
--- a/tools/deepin-os-release/main.cpp
+++ b/tools/deepin-os-release/main.cpp
@@ -2,6 +2,8 @@
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
+#define _GNU_SOURCE
+
 #include "dsysinfo.h"
 
 #include <QCoreApplication>
@@ -11,8 +13,40 @@
 #include <QFile>
 
 #include <stdio.h>
+#include <unistd.h> 
+#include <cstring>
 
 DCORE_USE_NAMESPACE
+
+class StderrFilterThread : public QThread
+{
+public:
+    explicit StderrFilterThread(int origStderr, int readFd, QObject *parent = nullptr)
+        : QThread(parent), m_origStderr(origStderr), m_readFd(readFd) {}
+
+protected:
+    void run() override
+    {
+        FILE *readEnd = fdopen(m_readFd, "r");
+        if (!readEnd) return;
+
+        char *line = nullptr;
+        size_t len = 0;
+        while (getline(&line, &len, readEnd) != -1) {
+            if (strstr(line, "WARNING: CPU random generator seem to be failing") ||
+                strstr(line, "WARNING: RDRND generated:")) {
+                continue; // 丢弃该行
+            }
+            write(m_origStderr, line, strlen(line));
+        }
+        free(line);
+        fclose(readEnd);
+    }
+
+private:
+    int m_origStderr;
+    int m_readFd;
+};
 
 bool distributionInfoValid() {
     return QFile::exists(DSysInfo::distributionInfoPath());
@@ -27,6 +61,16 @@ void printDistributionOrgInfo(DSysInfo::OrgType type) {
 
 int main(int argc, char *argv[])
 {
+    // 设置过滤器
+    int origStderr = dup(STDERR_FILENO);
+    int pipefd[2];
+    pipe(pipefd);
+    dup2(pipefd[1], STDERR_FILENO);
+    close(pipefd[1]);
+
+    StderrFilterThread *filterThread = new StderrFilterThread(origStderr, pipefd[0]);
+    filterThread->start(); 
+
     QCoreApplication app(argc, argv);
     Q_UNUSED(app)
 
@@ -122,6 +166,13 @@ int main(int argc, char *argv[])
             printDistributionOrgInfo(DSysInfo::Distributor);
         }
     }
+
+    // 清理
+    dup2(origStderr, STDERR_FILENO);  // 恢复 stderr
+    close(origStderr);
+
+    filterThread->wait();             
+    delete filterThread;
 
     return 0;
 }


### PR DESCRIPTION
在某些 AMD 平台（如 Ryzen 3 3200U）上更新 BIOS 后，CPU 的硬件随机数指令 RDRAND 持续返回异常值（0xffffffff）。这导致某些第三方加密库在动态库初始化阶段检测到失败，并向 stderr 输出固定的 WARNING 文本：
```
WARNING: CPU random generator seem to be failing, disabling hardware random number generation
WARNING: RDRND generated: 0xffffffff 0xffffffff 0xffffffff 0xffffffff
```
这样会影响到一些项目的cmake编译，如下：
```
# CMAKE generated file: DO NOT EDIT!
# Generated by "Unix Makefiles" Generator, CMake Version 4.3

# compile CXX with /usr/bin/c++
CXX_DEFINES = -DDEEPIN_DDE -DDSG_DATA_DIR=\"/usr/share/dsg\" -DDSYSINFO_PREFIX=\"\" -DPREFIX=\"/usr\" -DQT_CONCURRENT_LIB -DQT_CORE_LIB -DQT_DBUS_LIB -DQT_GUI_LIB -DQT_MESSAGELOGCONTEXT -DQT_NETWORK_LIB -DQT_NO_DEBUG -DQT_PRINTSUPPORT_LIB -DQT_SVG_LIB -DQT_WIDGETS_LIB -DQT_X11EXTRAS_LIB -DQT_XML_LIB -DQ_HOST_NAME=\"x86_64\" -DQ_HOST_X86_64 -DQ_OS_DEEPIN_VERSION="\"WARNING: CPU random generator seem to be failing, disabling hardware random number generation
WARNING: RDRND generated: 0xffffffff 0xffffffff 0xffffffff 0xffffffff
25\"" -DQ_OS_VERSION="\"WARNING: CPU random generator seem to be failing, disabling hardware random number generation
WARNING: RDRND generated: 0xffffffff 0xffffffff 0xffffffff 0xffffffff
25.3.1\""

CXX_INCLUDES = -I/home/ocean/Desktop/gxde-top-panel-plugins/obj-x86_64-linux-gnu/frame -I/home/ocean/Desktop/gxde-top-panel-plugins/frame -I/home/ocean/Desktop/gxde-top-panel-plugins/obj-x86_64-linux-gnu/frame/dde-dock_autogen/include -I/usr/include/libdframeworkdbus-2.0 -I/usr/include/x86_64-linux-gnu/qt5/QtGui/5.15.15 -I/usr/include/x86_64-linux-gnu/qt5/QtGui/5.15.15/QtGui -I/usr/include/x86_64-linux-gnu/qt5/QtCore/5.15.15 -I/usr/include/x86_64-linux-gnu/qt5/QtCore/5.15.15/QtCore -I/home/ocean/Desktop/gxde-top-panel-plugins/obj-x86_64-linux-gnu -I/usr/include/x86_64-linux-gnu/qt5/QGSettings -I/usr/include/glib-2.0 -I/usr/lib/x86_64-linux-gnu/glib-2.0/include -I/usr/include/sysprof-6 -I/usr/include/libmount -I/usr/include/blkid -I/home/ocean/Desktop/gxde-top-panel-plugins/frame/../interfaces -isystem /usr/include/dtk5/DWidget -isystem /usr/include/dtk5/DGui -isystem /usr/include/dtk5/DCore -isystem /usr/include/dtk5/DLog -isystem /usr/include/x86_64-linux-gnu/qt5 -isystem /usr/include/x86_64-linux-gnu/qt5/QtSvg -isystem /usr/include/x86_64-linux-gnu/qt5/QtWidgets -isystem /usr/include/x86_64-linux-gnu/qt5/QtGui -isystem /usr/include/x86_64-linux-gnu/qt5/QtCore -isystem /usr/lib/x86_64-linux-gnu/qt5/mkspecs/linux-g++ -isystem /usr/include/x86_64-linux-gnu/qt5/QtNetwork -isystem /usr/include/x86_64-linux-gnu/qt5/QtDBus -isystem /usr/include/x86_64-linux-gnu/qt5/QtPrintSupport -isystem /usr/include/x86_64-linux-gnu/qt5/QtXml -isystem /usr/include/x86_64-linux-gnu/qt5/QtConcurrent -isystem /usr/include/x86_64-linux-gnu/qt5/QtX11Extras

CXX_FLAGS = -g -Wall -Ofast -std=gnu++14   -DQ_OS_WARNING: CPU RANDOM GENERATOR SEEM TO BE FAILING, DISABLING HARDWARE RANDOM NUMBER GENERATION WARNING: RDRND GENERATED: 0XFFFFFFFF 0XFFFFFFFF 0XFFFFFFFF 0XFFFFFFFF GXDE -DQ_OS_DEEPIN_WARNING: CPU RANDOM GENERATOR SEEM TO BE FAILING, DISABLING HARDWARE RANDOM NUMBER GENERATION WARNING: RDRND GENERATED: 0XFFFFFFFF 0XFFFFFFFF 0XFFFFFFFF 0XFFFFFFFF COMMUNITY -fPIC

```
在终端的输出，修改前：
```
/usr/libexec/dtk5/DCore/bin/deepin-os-release --deepin-versionn-version
WARNING: CPU random generator seem to be failing, disabling hardware random number generation
WARNING: RDRND generated: 0xffffffff 0xffffffff 0xffffffff 0xffffffff
25ocean@ocean-hplaptop14sdk0xxx:~/Desktop/gxde-top-panel-plugins$
```
修改后：
```
ocean@ocean-hplaptop14sdk0xxx:~/Desktop/dtk5core$ /usr/libexec/dtk5/DCore/bin/deepin-os-release --deepin-version
25ocean@ocean-hplaptop14sdk0xxx:~/Desktop/dtk5core$
```
解决方法：
添加一个基于管道 + QThread 的 stderr 过滤器，过滤掉警告