### PR TITLE
fix: memory leak when overwriting cached DBus property values

### DIFF
--- a/src/util/ddbusextendedabstractinterface.cpp
+++ b/src/util/ddbusextendedabstractinterface.cpp
@@ -180,8 +180,10 @@ QVariant DDBusExtendedAbstractInterface::internalPropGet(const char *propname, v
         QVariant ret = property(propname);
 
 #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+        ret.metaType().destruct(propertyPtr);
         ret.metaType().construct(propertyPtr, ret.constData());
 #else
+        QMetaType::destruct(ret.userType(), propertyPtr);
         QMetaType::construct(ret.userType(), propertyPtr, ret.constData());
 
 #endif


### PR DESCRIPTION
In internalPropGet, QMetaType::construct is called on propertyPtr to copy the latest value from a DBus reply, but the old object at that address is never destructed. When the property type contains heap-allocated members (such as QByteArray pixels inside DBusImageList), this leak accumulates on every property read from the StatusNotifierItem interface (iconPixmap, attentionIconPixmap, overlayIconPixmap, ToolTip etc.).

Add destruct before construct to properly release the previous value. This reduces application-tray RSS growth from ~23 KB/s to ~3 KB/s.

internalPropGet 中每次 DBus 属性读取都通过 QMetaType::construct 将新值 原地复制到 propertyPtr，但旧对象未析构。对于包含堆内存成员的类型（如
DBusImageList 中的 QByteArray pixels），每次读取均导致旧数据泄漏。在 construct 前添加 destruct 释放旧值，application-tray 进程 RSS 增长从 约 23 KB/s 降至约 3 KB/s。

Log: fix: memory leak when overwriting cached DBus property values
Pms: BUG-359161
Change-Id: I80a2ed404b87bb87ce66fb3361ff7eb640b6c9fb