### PR TITLE
fix: add null pointer guard for distributionInfo

### DIFF
--- a/src/dsysinfo.cpp
+++ b/src/dsysinfo.cpp
@@ -949,6 +949,9 @@ QString DSysInfo::distributionOrgName(DSysInfo::OrgType type, const QLocale &loc
 
     QString fallback = type == Distribution ? QStringLiteral("Deepin") : QString();
 
+    if (!siGlobal->distributionInfo)
+        return fallback;
+
     return siGlobal->distributionInfo->localizedValue("Name", locale, distributionInfoSectionName(type), fallback);
 }
 
@@ -974,6 +977,9 @@ QPair<QString, QString> DSysInfo::distributionOrgWebsite(DSysInfo::OrgType type)
 
     QString fallbackSiteName = type == Distribution ? QStringLiteral("www.deepin.org") : QString();
     QString fallbackSiteUrl = type == Distribution ? QStringLiteral("https://www.deepin.org") : QString();
+
+    if (!siGlobal->distributionInfo)
+        return { fallbackSiteName, fallbackSiteUrl };
 
     return {
         siGlobal->distributionInfo->stringValue("WebsiteName", distributionInfoSectionName(type), fallbackSiteName),


### PR DESCRIPTION
在 distributionOrgName 和 distributionOrgWebsite 函数中增加 siGlobal->distributionInfo 的空指针检查，避免潜在的崩溃问题。

When distributionInfo is nullptr, return fallback values directly instead of accessing the null pointer.

## Summary by Sourcery

Bug Fixes:
- Handle null siGlobal->distributionInfo in distributionOrgName and distributionOrgWebsite by returning fallback values instead of dereferencing a null pointer.