### PR TITLE
fix: improve Windows settings backend and thread safety

### DIFF
--- a/src/settings/backend/qsettingbackend.cpp
+++ b/src/settings/backend/qsettingbackend.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2016 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2016 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
@@ -39,8 +39,11 @@ QSettingBackend::QSettingBackend(const QString &filepath, QObject *parent) :
     DSettingsBackend(parent), d_ptr(new QSettingBackendPrivate(this))
 {
     Q_D(QSettingBackend);
-
+#ifdef Q_OS_WIN
+    d->settings = new QSettings(filepath, QSettings::IniFormat, this);
+#else
     d->settings = new QSettings(filepath, QSettings::NativeFormat, this);
+#endif
     qDebug() << "create config" <<  d->settings->fileName();
 }
 

--- a/src/settings/dsettings.cpp
+++ b/src/settings/dsettings.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2016 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2016 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
@@ -261,6 +261,10 @@ void DSettings::setBackend(DSettingsBackend *backend)
 
     d->backend = backend;
 
+    // Load values BEFORE moving backend to worker thread.
+    // keys() and getOption() are cross-thread reads that must happen
+    // while the backend is still in the main thread.
+    loadValue();
 
     auto backendWriteThread = new QThread;
     d->backend->moveToThread(backendWriteThread);
@@ -279,9 +283,6 @@ void DSettings::setBackend(DSettingsBackend *backend)
     });
 
     backendWriteThread->start();
-
-    // load form backend
-    loadValue();
 }
 
 /*!
@@ -395,7 +396,9 @@ void DSettings::sync()
         return;
     }
 
-    d->backend->doSync();
+    // doSync() must run in the backend's worker thread.
+    // Use BlockingQueuedConnection so the caller waits for sync to finish.
+    QMetaObject::invokeMethod(d->backend, "doSync", Qt::BlockingQueuedConnection);
 }
 
 void DSettings::reset()


### PR DESCRIPTION
fix: 改进 Windows 设置后端和线程安全性

- Use QSettings::IniFormat on Windows instead of NativeFormat (registry), ensuring settings are stored as INI files consistent with Linux behavior
- Move loadValue() call before backend is moved to worker thread to prevent cross-thread race conditions when keys() and getOption() access the backend
- Use BlockingQueuedConnection for doSync() to ensure sync operations execute in the backend's worker thread while the caller waits for completion
- Update copyright years to 2026

- 在 Windows 上使用 QSettings::IniFormat 替代 NativeFormat（注册表格式）， 确保设置以 INI 文件形式存储，与 Linux 行为保持一致
- 将 loadValue() 调用移到 backend 移动到工作线程之前，防止 keys() 和 getOption() 跨线程访问 backend 导致竞态条件
- 使用 BlockingQueuedConnection 执行 doSync()，确保同步操作在 backend 的 工作线程中执行，同时调用者等待完成
- 更新版权年份至 2026

## Summary by Sourcery

Improve Windows settings backend behavior and thread safety for configuration loading and syncing.

Bug Fixes:
- Prevent cross-thread race conditions by loading settings before moving the backend to its worker thread.
- Ensure settings synchronization runs in the backend worker thread while the caller blocks until completion.

Enhancements:
- Use INI-based QSettings storage on Windows to align configuration persistence with Linux behavior.

Documentation:
- Update SPDX copyright years to 2026 in settings-related source files.