### PR TITLE
fix: add dev-tools package dependencies to DTK dev packages

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -46,6 +46,7 @@ Description: Development ToolKit Core Utilities (DTK6 with Qt6)
 Package: libdtk6core-dev
 Architecture: any
 Depends: libdtk6core( =${binary:Version}),
+ libdtk6core-bin( =${binary:Version}),
  libdtkcommon-dev(>=5.6.16), libdtk6log-dev
 Build-Profiles: <!nodtk6>
 Description: Development ToolKit Core Devel Library (DTK6 with Qt6)
@@ -84,6 +85,7 @@ Description: Development ToolKit Core Utilities (DTK5 with Qt5)
 Package: libdtkcore-dev
 Architecture: any
 Depends: libdtkcore5( =${binary:Version}),
+ libdtkcore5-bin( =${binary:Version}),
  libdtkcommon-dev(>=5.6.16), libdtklog-dev
 Build-Profiles: <!nodtk5>
 Description: Development ToolKit Core Devel Library (DTK5 with Qt5)


### PR DESCRIPTION
1. Add libdtk6core-bin dependency to libdtk6core-dev package (DTK6)
2. Add libdtkcore5-bin dependency to libdtkcore-dev package (DTK5)
3. Ensure development packages pull in matching version tools packages
4. Maintain consistent version alignment between dev libraries and tools

Log: Enhanced DTK development packages to include matching tools
dependencies

Influence:
1. Verify dev package installation includes corresponding tools packages
2. Confirm version alignment between dev and tools packages
3. Test installation with versioned dependencies in offline environments
4. Validate compatibility with existing build systems using DTK dev
packages

chore: 为 DTK 开发包添加配套工具包依赖

1. 为 libdtk6core-dev 包（DTK6）添加 libdtk6core-bin 依赖
2. 为 libdtkcore-dev 包（DTK5）添加 libdtkcore5-bin 依赖
3. 确保开发包安装时自动引入对应版本的工具包
4. 保持开发库与工具包之间版本一致性

Log: 增强 DTK 开发包，新增配套工具包依赖

Influence:
1. 验证开发包安装时是否包含对应的工具包
2. 确认开发包与工具包之间版本一致性
3. 在离线环境中测试带版本依赖的安装过程
4. 验证现有使用 DTK 开发包的构建系统兼容性

## Summary by Sourcery

Enhancements:
- Update DTK6 and DTK5 development package metadata so installing dev libraries also pulls in matching tools binaries.